### PR TITLE
Add the no-interaction flag to composer global require commands

### DIFF
--- a/images/5.3-apache/Dockerfile
+++ b/images/5.3-apache/Dockerfile
@@ -76,7 +76,7 @@ RUN sed -i '/jessie-updates/d' /etc/apt/sources.list \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && sh -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && sh -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/5.3-fpm/Dockerfile
+++ b/images/5.3-fpm/Dockerfile
@@ -73,7 +73,7 @@ RUN sed -i '/jessie-updates/d' /etc/apt/sources.list \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/5.4-apache/Dockerfile
+++ b/images/5.4-apache/Dockerfile
@@ -72,7 +72,7 @@ RUN sed -i '/jessie-updates/d' /etc/apt/sources.list \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/5.4-fpm/Dockerfile
+++ b/images/5.4-fpm/Dockerfile
@@ -68,7 +68,7 @@ RUN sed -i '/jessie-updates/d' /etc/apt/sources.list \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/5.5-apache/Dockerfile
+++ b/images/5.5-apache/Dockerfile
@@ -70,7 +70,7 @@ RUN sed -i '/jessie-updates/d' /etc/apt/sources.list \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/5.5-fpm/Dockerfile
+++ b/images/5.5-fpm/Dockerfile
@@ -69,7 +69,7 @@ RUN sed -i '/jessie-updates/d' /etc/apt/sources.list \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/5.6-apache/Dockerfile
+++ b/images/5.6-apache/Dockerfile
@@ -71,7 +71,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/5.6-fpm/Dockerfile
+++ b/images/5.6-fpm/Dockerfile
@@ -72,7 +72,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.0-apache/Dockerfile
+++ b/images/7.0-apache/Dockerfile
@@ -71,7 +71,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.0-fpm/Dockerfile
+++ b/images/7.0-fpm/Dockerfile
@@ -71,7 +71,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.1-apache/Dockerfile
+++ b/images/7.1-apache/Dockerfile
@@ -79,7 +79,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.1-fpm/Dockerfile
+++ b/images/7.1-fpm/Dockerfile
@@ -79,7 +79,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.2-apache/Dockerfile
+++ b/images/7.2-apache/Dockerfile
@@ -77,7 +77,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.2-fpm/Dockerfile
+++ b/images/7.2-fpm/Dockerfile
@@ -77,7 +77,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.3-apache/Dockerfile
+++ b/images/7.3-apache/Dockerfile
@@ -77,7 +77,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.3-fpm/Dockerfile
+++ b/images/7.3-fpm/Dockerfile
@@ -77,7 +77,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/8.0-apache/Dockerfile
+++ b/images/8.0-apache/Dockerfile
@@ -73,7 +73,6 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.0.7 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  #&& su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/8.0-fpm/Dockerfile
+++ b/images/8.0-fpm/Dockerfile
@@ -73,7 +73,6 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.0.7 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  #&& su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/8.1-apache/Dockerfile
+++ b/images/8.1-apache/Dockerfile
@@ -73,7 +73,6 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.0.7 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  #&& su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/8.1-fpm/Dockerfile
+++ b/images/8.1-fpm/Dockerfile
@@ -73,7 +73,6 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.0.7 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  #&& su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \


### PR DESCRIPTION
Fixes https://github.com/lando/php/issues/19

I see now that updating to the PHP 7.4 image would get us the most recent Composer version and avoid installing hirak/prestissimo as well.