### PR TITLE
Fix PHP Image Build Matrix

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -15,8 +15,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lando-version:
-          - 3-dev-slim
         include:
           - image: php
             tag: 8.3-fpm-4
@@ -105,10 +103,10 @@ jobs:
           lando-plugin: true
           version: dev
           sync: false
-      - name: Setup lando ${{ matrix.lando-version }}
+      - name: Setup lando 3-dev-slim
         uses: lando/setup-lando@v2
         with:
-          lando-version: ${{ matrix.lando-version }}
+          lando-version: 3-dev-slim
           config: |
             setup.skipCommonPlugins=true
             setup.plugins.@lando/php=/home/runner/work/php/php

--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set tag suffix
         id: pr
         if: ${{ github.event_name == 'pull_request' }}
-        run: echo "tag-suffix=-edge" >> "$GITHUB_OUTPUT"
+        run: echo "tag_suffix=-edge" >> "$GITHUB_OUTPUT"
       # Build our images.
       - name: Login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -69,20 +69,20 @@ jobs:
       - name: Set tag suffix
         id: pr
         if: ${{ github.event_name == 'pull_request' }}
-        run: echo "tag-suffix=-edge" >> $GITHUB_OUTPUT
+        run: echo "tag-suffix=-edge" >> "$GITHUB_OUTPUT"
       # Build our images.
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push devwithlando/${{ matrix.image }}:${{ matrix.tag }}${{ steps.pr.outputs.TAG_SUFFIX }}
+      - name: Build and push devwithlando/${{ matrix.image }}:${{ matrix.tag }}${{ steps.pr.outputs.tag_suffix }}
         uses: docker/build-push-action@v4
         with:
           context: ${{ matrix.context }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: devwithlando/${{ matrix.image }}:${{ matrix.tag }}${{ steps.pr.outputs.TAG_SUFFIX }}
+          tags: devwithlando/${{ matrix.image }}:${{ matrix.tag }}${{ steps.pr.outputs.tag_suffix }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -25,7 +25,7 @@ description: Learn what extensions are installed in the Lando PHP plugin
 | gettext   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | hash      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | iconv     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| imagick   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| imagick   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  *  |
 | imap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | intl      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | json      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
@@ -66,6 +66,11 @@ description: Learn what extensions are installed in the Lando PHP plugin
 | zlib      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 
 Note that `xdebug` is off by default but you can enable it by setting your `php` services config to `xdebug: true`. Read more about this in "Configuration" above.
+
+::: warning
+Note that imagick is temporarily unavailable on PHP 8.3, due to a pending issue waiting to get released on the imagick project: https://github.com/Imagick/imagick/pull/641 
+:::
+
 
 ## Adding or removing extensions
 

--- a/images/8.3-apache/Dockerfile
+++ b/images/8.3-apache/Dockerfile
@@ -42,14 +42,12 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     xfonts-base \
     zlib1g-dev \
   && pecl install apcu \
-  && pecl install imagick \
   && pecl install memcached \
   && pecl install oauth \
   && pecl install redis-6.0.2 \
   && pecl install xdebug-3.3.0alpha3 \
   && docker-php-ext-configure ldap --with-libdir=lib/$(uname -m)-linux-gnu/ \
   && docker-php-ext-enable apcu \
-  && docker-php-ext-enable imagick \
   && docker-php-ext-enable memcached \
   && docker-php-ext-enable oauth \
   && docker-php-ext-enable redis \

--- a/images/8.3-fpm/Dockerfile
+++ b/images/8.3-fpm/Dockerfile
@@ -42,14 +42,12 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     xfonts-base \
     zlib1g-dev \
   && pecl install apcu \
-  && pecl install imagick \
   && pecl install memcached \
   && pecl install oauth \
   && pecl install redis-6.0.2 \
   && pecl install xdebug-3.3.0alpha3 \
   && docker-php-ext-configure ldap --with-libdir=lib/$(uname -m)-linux-gnu/ \
   && docker-php-ext-enable apcu \
-  && docker-php-ext-enable imagick \
   && docker-php-ext-enable memcached \
   && docker-php-ext-enable oauth \
   && docker-php-ext-enable redis \


### PR DESCRIPTION
Fixes #98. Underlying problem is an issue generating the build matrix; for some reason the lando-version value is creating a single build item, the build for `7.3-apache-4`, which is the bottom most build in the `includes` matrix item.

This PR "fixes" the problem by hardcoding 3-dev-slim as the Lando version to use in testing the PHP images.