### PR TITLE
Improve composer version defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
 * Added logic to allow default `composer` version to be set based on PHP version.
+* Added `2.2` and `2.2-latest` shorthand options to install the latest stable 2.2 LTS version of `composer`.
 * Set default `composer` version to `2.8.3`
 * Set default `composer` version to `2.2.24` for PHP 5.3-7.2
 * Set default `composer` version to `1.10.27` for PHP <= 5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 * Added logic to allow default `composer` version to be set based on PHP version.
 * Added `2.2` and `2.2-latest` shorthand options to install the latest stable 2.2 LTS version of `composer`.
-* Set default `composer` version to `2.8.3`
-* Set default `composer` version to `2.2.24` for PHP 5.3-7.2
-* Set default `composer` version to `1.10.27` for PHP <= 5.2
+* Set default `composer` version to `2-latest`
+* Set default `composer` version to `2.2-latest` for PHP 5.3-7.2
+* Set default `composer` version to `1-latest` for PHP <= 5.2
+* Removed `composer` installation from images to prefer installing during app build
 * Fixed bug causing `composer` 2.2.x to be installed when `composer_version` was set to a single digit version such as `1`
 * Fixed mismatched `libsqlite3-dev` and `libsqlite3-0` versions in PHP 8.3 and 8.4 images
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
 * Added logic to allow default `composer` version to be set based on PHP version.
-* Set default `composer` version to `2.8.2`
+* Set default `composer` version to `2.8.3`
 * Set default `composer` version to `2.2.24` for PHP 5.3-7.2
 * Set default `composer` version to `1.10.27` for PHP <= 5.2
 * Fixed bug causing `composer` 2.2.x to be installed when `composer_version` was set to a single digit version such as `1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * Set default `composer` version to `2.8.1`
 * Set default `composer` version to `2.2.24` for PHP 5.3-7.2
 * Set default `composer` version to `1.10.27` for PHP <= 5.2
-* Fixed mismatched `libsqlite3-dev` and `libsqlite3-0` versions in PHP 8.3 and 8.4 images.
+* Fixed bug causing `composer` 2.2.x to be installed when `composer_version` was set to a single digit version such as `1`
+* Fixed mismatched `libsqlite3-dev` and `libsqlite3-0` versions in PHP 8.3 and 8.4 images
 
 ## v1.6.4 - [December 14, 2024](https://github.com/lando/php/releases/tag/v1.6.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Added logic to allow default `composer` version to be set based on PHP version.
+* Set default `composer` version to `2.8.1`
+* Set default `composer` version to `2.2.24` for PHP 5.3-7.2
+* Set default `composer` version to `1.10.27` for PHP <= 5.2
 * Fixed mismatched `libsqlite3-dev` and `libsqlite3-0` versions in PHP 8.3 and 8.4 images.
 
 ## v1.6.4 - [December 14, 2024](https://github.com/lando/php/releases/tag/v1.6.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
 * Added logic to allow default `composer` version to be set based on PHP version.
-* Set default `composer` version to `2.8.1`
+* Set default `composer` version to `2.8.2`
 * Set default `composer` version to `2.2.24` for PHP 5.3-7.2
 * Set default `composer` version to `1.10.27` for PHP <= 5.2
 * Fixed bug causing `composer` 2.2.x to be installed when `composer_version` was set to a single digit version such as `1`

--- a/builders/php.js
+++ b/builders/php.js
@@ -156,6 +156,7 @@ module.exports = {
   parent: '_appserver',
   builder: (parent, config) => class LandoPhp extends parent {
     constructor(id, options = {}, factory) {
+      const lando = _.get(options, '_app._lando');
       options = parseConfig(_.merge({}, config, options));
       // Mount our default php config
       options.volumes.push(`${options.confDest}/${options.defaultFiles._php}:${options.remoteFiles._php}`);
@@ -202,10 +203,12 @@ module.exports = {
       // Determine the appropriate composer version if not already set
       if (_.isEmpty(options.composer_version) || options.composer_version === true) {
         options.composer_version = getComposerVersion(options.version);
+        lando.log.debug('Setting composer version to %s for PHP %s', options.composer_version, options.version);
       }
 
       // Install the desired composer version
       if (options.composer_version) {
+        lando.log.debug('Installing composer version %s', options.composer_version);
         const commands = [`/helpers/install-composer.sh ${options.composer_version}`];
         addBuildStep(commands, options._app, options.name, 'build_internal', true);
       }

--- a/builders/php.js
+++ b/builders/php.js
@@ -9,13 +9,18 @@ const addBuildStep = require('./../utils/add-build-step');
 /**
  * Get the appropriate Composer version based on the PHP version.
  * @param {string} phpVersion - The PHP version.
- * @return {string} - The Composer version.
+ * @return {string|boolean} - The Composer version or false if we cannot parse the version.
  */
 const getDefaultComposerVersion = phpVersion => {
-  if (semver.lt(semver.coerce(phpVersion), '5.3.2')) {
+  phpVersion = semver.coerce(phpVersion);
+  // Don't set a default composer version if we cannot
+  // parse the version such as with `custom`.
+  if (!phpVersion) return false;
+
+  if (semver.lt(phpVersion, '5.3.2')) {
     // Use Composer 1 for PHP < 5.3.2
     return '1';
-  } else if (semver.lt(semver.coerce(phpVersion), '7.3.0')) {
+  } else if (semver.lt(phpVersion, '7.3.0')) {
     // Use Composer 2.2 LTS for PHP < 7.3
     return '2.2.24';
   } else {

--- a/builders/php.js
+++ b/builders/php.js
@@ -6,6 +6,12 @@ const path = require('path');
 const semver = require('semver');
 const addBuildStep = require('./../utils/add-build-step');
 
+const composerVersions = {
+  '1': '1.10.27',
+  '2': '2.8.3',
+  '2.2': '2.2.24',
+};
+
 /**
  * Get the appropriate Composer version based on the PHP version.
  * @param {string} phpVersion - The PHP version.
@@ -19,13 +25,13 @@ const getDefaultComposerVersion = phpVersion => {
 
   if (semver.lt(phpVersion, '5.3.2')) {
     // Use Composer 1 for PHP < 5.3.2
-    return '1';
+    return composerVersions['1'];
   } else if (semver.lt(phpVersion, '7.3.0')) {
     // Use Composer 2.2 LTS for PHP < 7.3
-    return '2.2.24';
+    return composerVersions['2.2'];
   } else {
     // Use Composer 2 for PHP >= 7.3
-    return '2.8.2';
+    return composerVersions['2'];
   }
 };
 

--- a/builders/php.js
+++ b/builders/php.js
@@ -186,11 +186,6 @@ module.exports = {
       };
       options.info = {via: options.via};
 
-      // Determine the appropriate composer version if not already set
-      if (!options.composer_version) {
-        options.composer_version = getComposerVersion(options.version);
-      }
-
       // Add our composer things to run step
       if (!_.isEmpty(options.composer)) {
         const commands =
@@ -201,6 +196,11 @@ module.exports = {
       // Add activate steps for xdebug
       if (options.xdebug) {
         addBuildStep(['docker-php-ext-enable xdebug'], options._app, options.name, 'build_as_root_internal');
+      }
+
+      // Determine the appropriate composer version if not already set
+      if (_.isEmpty(options.composer_version)) {
+        options.composer_version = getComposerVersion(options.version);
       }
 
       // Install the desired composer version

--- a/builders/php.js
+++ b/builders/php.js
@@ -25,7 +25,7 @@ const getDefaultComposerVersion = phpVersion => {
     return '2.2.24';
   } else {
     // Use Composer 2 for PHP >= 7.3
-    return '2.8.1';
+    return '2.8.2';
   }
 };
 

--- a/builders/php.js
+++ b/builders/php.js
@@ -127,6 +127,7 @@ module.exports = {
     ],
     confSrc: path.resolve(__dirname, '..', 'config'),
     command: ['sh -c \'a2enmod rewrite && apache2-foreground\''],
+    composer_version: '',
     phpServer: 'apache',
     defaultFiles: {
       _php: 'php.ini',
@@ -199,7 +200,7 @@ module.exports = {
       }
 
       // Determine the appropriate composer version if not already set
-      if (_.isEmpty(options.composer_version)) {
+      if (_.isEmpty(options.composer_version) || options.composer_version === true) {
         options.composer_version = getComposerVersion(options.version);
       }
 

--- a/builders/php.js
+++ b/builders/php.js
@@ -6,32 +6,25 @@ const path = require('path');
 const semver = require('semver');
 const addBuildStep = require('./../utils/add-build-step');
 
-const composerVersions = {
-  '1': '1.10.27',
-  '2': '2.8.3',
-  '2.2': '2.2.24',
-};
-
 /**
  * Get the appropriate Composer version based on the PHP version.
- * @param {string} phpVersion - The PHP version.
+ * @param {semver} phpSemver - The PHP semantic version.
  * @return {string|boolean} - The Composer version or false if we cannot parse the version.
  */
-const getDefaultComposerVersion = phpVersion => {
-  phpVersion = semver.coerce(phpVersion);
+const getDefaultComposerVersion = phpSemver => {
   // Don't set a default composer version if we cannot
   // parse the version such as with `custom`.
-  if (!phpVersion) return false;
+  if (!phpSemver) return false;
 
-  if (semver.lt(phpVersion, '5.3.2')) {
+  if (semver.lt(phpSemver, '5.3.2')) {
     // Use Composer 1 for PHP < 5.3.2
-    return composerVersions['1'];
-  } else if (semver.lt(phpVersion, '7.3.0')) {
+    return '1';
+  } else if (semver.lt(phpSemver, '7.3.0')) {
     // Use Composer 2.2 LTS for PHP < 7.3
-    return composerVersions['2.2'];
+    return '2.2';
   } else {
     // Use Composer 2 for PHP >= 7.3
-    return composerVersions['2'];
+    return '2';
   }
 };
 
@@ -60,13 +53,25 @@ const nginxConfig = options => ({
 const xdebugConfig = host => ([
   `client_host=${host}`,
   'discover_client_host=1',
- 'log=/tmp/xdebug.log',
- 'remote_enable=true',
+  'log=/tmp/xdebug.log',
+  'remote_enable=true',
   `remote_host=${host}`,
 ].join(' '));
 
-/*
- * Helper to build a package string
+/**
+ * Helper function to build a package string by combining package name and version
+ *
+ * @param {string} pkg - The package name
+ * @param {string} version - The package version
+ * @return {string} The formatted package string, either "pkg:version" or just "pkg" if version is empty
+ *
+ * @example
+ * // Returns "php:7.4"
+ * pkger('php', '7.4');
+ *
+ * @example
+ * // Returns "mysql"
+ * pkger('mysql', '');
  */
 const pkger = (pkg, version) => (!_.isEmpty(version)) ? `${pkg}:${version}` : pkg;
 
@@ -172,11 +177,15 @@ module.exports = {
       // Merge the user config onto the default options
       options = parseConfig(_.merge({}, config, options));
 
+      // Get the semver of the PHP version, NULL if we cannot parse it
+      const phpSemver = semver.coerce(options.version);
+      phpSemver && debug('Parsed PHP semantic version: %s', phpSemver);
+
       // Mount our default php config
       options.volumes.push(`${options.confDest}/${options.defaultFiles._php}:${options.remoteFiles._php}`);
       options.volumes.push(`${options.confDest}/${options.defaultFiles.pool}:${options.remoteFiles.pool}`);
       // Shift on the docker entrypoint if this is a more recent version
-      if (options.version !== 'custom' && semver.gt(semver.coerce(options.version), '5.5.0')) {
+      if (phpSemver && semver.gt(phpSemver, '5.5.0')) {
         options.command.unshift('docker-php-entrypoint');
       }
 
@@ -202,28 +211,38 @@ module.exports = {
       };
       options.info = {via: options.via};
 
-      // Add our composer things to run step
+      // Determine the appropriate composer version to install if not specified
+      if (options.composer_version === true || options.composer_version === '') {
+        options.composer_version = getDefaultComposerVersion(phpSemver);
+      } else if (typeof options.composer_version === 'number') {
+        options.composer_version = options.composer_version.toString();
+      }
+      const usingComposer1 = options.composer_version && semver.satisfies(options.composer_version, '1.x');
+
+      // Add prestissimo as a global package for Composer 1.x performance improvements. Requires PHP >= 5.3
+      if (usingComposer1 && phpSemver && semver.gte(phpSemver, '5.3.0')) {
+        options.composer = options.composer || {};
+        options.composer = {'hirak/prestissimo': '*', ...options.composer};
+      }
+
+      // Add build step to enable xdebug
+      if (options.xdebug) {
+        addBuildStep(['docker-php-ext-enable xdebug'], options._app, options.name, 'build_as_root_internal');
+      }
+
+      // Add build step to install our Composer global packages
       if (!_.isEmpty(options.composer)) {
         const commands =
           require('../utils/get-install-commands')(options.composer, pkger, ['composer', 'global', 'require', '-n']);
         addBuildStep(commands, options._app, options.name, 'build_internal');
       }
 
-      // Add activate steps for xdebug
-      if (options.xdebug) {
-        addBuildStep(['docker-php-ext-enable xdebug'], options._app, options.name, 'build_as_root_internal');
-      }
-
-      // Determine the appropriate composer version if not already set
-      if (options.composer_version === true || options.composer_version === '') {
-        options.composer_version = getDefaultComposerVersion(options.version);
-      }
-
-      // Install the desired composer version
+      // Install the desired composer version as the first `build_internal` build step
       if (options.composer_version) {
         debug('Installing composer version %s', options.composer_version);
         const commands = [`/helpers/install-composer.sh ${options.composer_version}`];
-        addBuildStep(commands, options._app, options.name, 'build_internal', true);
+        const firstStep = true;
+        addBuildStep(commands, options._app, options.name, 'build_internal', firstStep);
       }
 
       // Add in nginx if we need to

--- a/docs/config.md
+++ b/docs/config.md
@@ -181,6 +181,10 @@ composer_version: 1-latest
 composer_version: 2
 composer_version: 2-latest
 
+# Install the latest stable 2.2 LTS version
+composer_version: 2.2
+composer_version: 2.2-latest
+
 # Install latest pre-release version
 composer_version: preview
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -18,7 +18,7 @@ services:
     webroot: .
     xdebug: false
     composer: []
-    composer_version: '2.2.12'
+    composer_version: '2'
     # Below only valid for via: cli
     command: tail -f /dev/null
     config:
@@ -161,16 +161,22 @@ You can use `lando info --deep | grep IPAddress` to help discover the correct ho
 
 ## Installing composer
 
-As of Lando `3.0.17` you can configure the version of `composer` you would like to install. This _should_ respect any of the versions listed on the [Composer download page](https://getcomposer.org/download/) but it is required you specify down to the patch version.
+Lando automatically installs the latest compatible version of Composer based on your specified PHP version:
+
+- PHP >= 7.3: Composer 2.x
+- PHP >= 5.3.2 and < 7.3: Composer 2.2 LTS
+- PHP < 5.3.2: Composer 1.x
+
+You can customize the Composer version by specifying either a specific version number or using a channel alias:
 
 ```yaml
 services:
   myservice:
-    type: php
-    composer_version: "1.10.1"
+    type: php:8.2
+    composer_version: "2.6.5"  # Install specific version
 ```
 
-You can also choose to ignore the `composer` install step by setting `composer_version: false`. This will use whatever version of `composer` was last bundled with our `php` image. The following "convenience flags" are also available:
+The following channel aliases are available:
 
 ```yaml
 # Install the latest stable 1.x version
@@ -191,6 +197,8 @@ composer_version: preview
 # Install latest commit
 composer_version: snapshot
 ```
+
+You can disable Composer installation entirely by setting `composer_version: false`.
 
 ## Installing global dependencies
 

--- a/examples/5.6/.lando.yml
+++ b/examples/5.6/.lando.yml
@@ -5,10 +5,9 @@ events:
 services:
   defaults:
     type: php:5.6
-    composer_version: false
   cli:
     type: php:5.6
-    composer_version: false
+    composer_version: 1
     via: cli
   cliworker:
     type: php:5.6
@@ -17,7 +16,7 @@ services:
     command: sleep infinity
   custom:
     type: php:5.6
-    composer_version: false
+    composer_version: true
     via: nginx
     ssl: true
     webroot: web

--- a/examples/5.6/README.md
+++ b/examples/5.6/README.md
@@ -61,8 +61,9 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 # Should use specified php version if given
 lando exec custom -- php -v | grep "PHP 5.6"
 
-# Should install composer 1.x if composer_version is set to true
-lando exec custom -- composer --version --no-ansi | grep "Composer version 1."
+# Should install composer 2.2.x if composer_version is set to true
+lando exec custom -- composer --version --no-ansi
+!! | grep "Composer version 2.2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -77,7 +78,8 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | grep "Composer version 1."
+lando exec cli -- composer --version --no-ansi
+!! | grep "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -112,8 +114,9 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 # Should allow cli services to specify a boot up command
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
-# Should install the latest composer 1.x by default.
-lando exec cliworker -- composer --version --no-ansi | grep "Composer version 1."
+# Should install the latest composer 2.2.x by default.
+lando exec cliworker -- composer --version --no-ansi
+!! | grep "Composer version 2.2."
 ```
 
 ## Destroy tests

--- a/examples/5.6/README.md
+++ b/examples/5.6/README.md
@@ -112,8 +112,8 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 # Should allow cli services to specify a boot up command
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
-# Should install the latest composer 2.2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
+# Should use preinstalled composer 1.x when composer_version is false
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 ```
 
 ## Destroy tests

--- a/examples/5.6/README.md
+++ b/examples/5.6/README.md
@@ -44,8 +44,8 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 # Should have COMPOSER_MEMORY_LIMIT set to -1
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
-# Should install composer 1.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 1."
+# Should install composer 2.2.x by default
+lando exec defaults -- composer --version --no-ansi | grep "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"

--- a/examples/5.6/README.md
+++ b/examples/5.6/README.md
@@ -45,7 +45,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -62,7 +62,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 5.6"
 
 # Should install composer 2.2.x if composer_version is set to true
-lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -77,7 +77,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -113,7 +113,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 ```
 
 ## Destroy tests

--- a/examples/5.6/README.md
+++ b/examples/5.6/README.md
@@ -45,7 +45,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -62,8 +62,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 5.6"
 
 # Should install composer 2.2.x if composer_version is set to true
-lando exec custom -- composer --version --no-ansi
-!! | grep "Composer version 2.2."
+lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,8 +77,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi
-!! | grep "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -115,8 +113,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.2.x by default.
-lando exec cliworker -- composer --version --no-ansi
-!! | grep "Composer version 2.2."
+lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
 ```
 
 ## Destroy tests

--- a/examples/5.6/README.md
+++ b/examples/5.6/README.md
@@ -45,7 +45,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -62,7 +62,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 5.6"
 
 # Should install composer 2.2.x if composer_version is set to true
-lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
+lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -77,7 +77,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -113,7 +113,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
+lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
 ```
 
 ## Destroy tests

--- a/examples/5.6/README.md
+++ b/examples/5.6/README.md
@@ -45,7 +45,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -62,7 +62,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 5.6"
 
 # Should install composer 2.2.x if composer_version is set to true
-lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -77,7 +77,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -113,7 +113,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 ```
 
 ## Destroy tests

--- a/examples/7.0/.lando.yml
+++ b/examples/7.0/.lando.yml
@@ -5,10 +5,9 @@ events:
 services:
   defaults:
     type: php:7.0
-    composer_version: false
   cli:
     type: php:7.0
-    composer_version: false
+    composer_version: 1
     via: cli
     build_as_root:
       - echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list

--- a/examples/7.0/README.md
+++ b/examples/7.0/README.md
@@ -46,7 +46,8 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi
+!! | grep "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +64,8 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.0"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | grep "Composer version 2."
+lando exec custom -- composer --version --no-ansi
+!! | grep "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,7 +80,8 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | grep "Composer version 1."
+lando exec cli -- composer --version --no-ansi
+!! | grep "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -113,8 +116,9 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 # Should allow cli services to specify a boot up command
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
-# Should install the latest composer 1.x by default.
-lando exec cliworker -- composer --version --no-ansi | grep "Composer version 1."
+# Should install the latest composer 1.x when composer_version is false
+lando exec cliworker -- composer --version --no-ansi
+!! | grep "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.0/README.md
+++ b/examples/7.0/README.md
@@ -46,8 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi
-!! | grep "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -64,8 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.0"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi
-!! | grep "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -80,8 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi
-!! | grep "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -117,8 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x when composer_version is false
-lando exec cliworker -- composer --version --no-ansi
-!! | grep "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.0/README.md
+++ b/examples/7.0/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.0"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,7 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -114,7 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x when composer_version is false
-lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.0/README.md
+++ b/examples/7.0/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.0"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,7 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -114,7 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x when composer_version is false
-lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.0/README.md
+++ b/examples/7.0/README.md
@@ -45,8 +45,8 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 # Should have COMPOSER_MEMORY_LIMIT set to -1
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
-# Should install composer 1.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 1."
+# Should install composer 2.2.x by default
+lando exec defaults -- composer --version --no-ansi | grep "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"

--- a/examples/7.0/README.md
+++ b/examples/7.0/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.0"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,7 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -114,7 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x when composer_version is false
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.1/.lando.yml
+++ b/examples/7.1/.lando.yml
@@ -5,10 +5,9 @@ events:
 services:
   defaults:
     type: php:7.1
-    composer_version: false
   cli:
     type: php:7.1
-    composer_version: false
+    composer_version: 1
     via: cli
     build_as_root:
       - curl -sL https://deb.nodesource.com/setup_14.x | bash -

--- a/examples/7.1/README.md
+++ b/examples/7.1/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.1"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,7 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -114,7 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x if composer_version is set to false
-lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.1/README.md
+++ b/examples/7.1/README.md
@@ -46,7 +46,8 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi
+!! | grep "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +64,8 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.1"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | grep "Composer version 2."
+lando exec custom -- composer --version --no-ansi
+!! | grep "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,7 +80,8 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | grep "Composer version 1."
+lando exec cli -- composer --version --no-ansi
+!! | grep "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -113,8 +116,9 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 # Should allow cli services to specify a boot up command
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
-# Should install the latest composer 1.x by default.
-lando exec cliworker -- composer --version --no-ansi | grep "Composer version 1."
+# Should install the latest composer 1.x if composer_version is set to false
+lando exec cliworker -- composer --version --no-ansi
+!! | grep "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.1/README.md
+++ b/examples/7.1/README.md
@@ -45,8 +45,8 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 # Should have COMPOSER_MEMORY_LIMIT set to -1
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
-# Should install composer 1.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 1."
+# Should install composer 2.2.x by default
+lando exec defaults -- composer --version --no-ansi | grep "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"

--- a/examples/7.1/README.md
+++ b/examples/7.1/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.1"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,7 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -114,7 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x if composer_version is set to false
-lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.1/README.md
+++ b/examples/7.1/README.md
@@ -46,8 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi
-!! | grep "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -64,8 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.1"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi
-!! | grep "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -80,8 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi
-!! | grep "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -117,8 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x if composer_version is set to false
-lando exec cliworker -- composer --version --no-ansi
-!! | grep "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.1/README.md
+++ b/examples/7.1/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
+lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.1"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,7 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -114,7 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x if composer_version is set to false
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.2/.lando.yml
+++ b/examples/7.2/.lando.yml
@@ -5,10 +5,9 @@ events:
 services:
   defaults:
     type: php:7.2
-    composer_version: false
   cli:
     type: php:7.2
-    composer_version: false
+    composer_version: 1
     via: cli
     build_as_root:
       - curl -sL https://deb.nodesource.com/setup_14.x | bash -

--- a/examples/7.2/README.md
+++ b/examples/7.2/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2"
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2"
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.2"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,7 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -114,7 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x if composer_version is set to false
-lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.2/README.md
+++ b/examples/7.2/README.md
@@ -45,8 +45,8 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 # Should have COMPOSER_MEMORY_LIMIT set to -1
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
-# Should install composer 1.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 1."
+# Should install composer 2.2.x by default
+lando exec defaults -- composer --version --no-ansi | grep "Composer version 2.2"
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"

--- a/examples/7.2/README.md
+++ b/examples/7.2/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2"
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2"
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.2"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,7 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -114,7 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x if composer_version is set to false
-lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.2/README.md
+++ b/examples/7.2/README.md
@@ -46,8 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi
-!! | grep "Composer version 2.2"
+lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2"
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -64,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.2"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | grep "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -79,8 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi
-!! | grep "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -116,8 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x if composer_version is set to false
-lando exec cliworker -- composer --version --no-ansi
-!! | grep "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.2/README.md
+++ b/examples/7.2/README.md
@@ -46,7 +46,8 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 2.2"
+lando exec defaults -- composer --version --no-ansi
+!! | grep "Composer version 2.2"
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -78,7 +79,8 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | grep "Composer version 1."
+lando exec cli -- composer --version --no-ansi
+!! | grep "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -113,8 +115,9 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 # Should allow cli services to specify a boot up command
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
-# Should install the latest composer 1.x by default.
-lando exec cliworker -- composer --version --no-ansi | grep "Composer version 1."
+# Should install the latest composer 1.x if composer_version is set to false
+lando exec cliworker -- composer --version --no-ansi
+!! | grep "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.2/README.md
+++ b/examples/7.2/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2"
+lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2"
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.2"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -78,7 +78,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the latest composer 1.x using the 1 flag
-lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
+lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -114,7 +114,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 1.x if composer_version is set to false
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
+lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.3/README.md
+++ b/examples/7.3/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.3"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the composer 2.x using the false flag
-lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.3/README.md
+++ b/examples/7.3/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.3"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the composer 2.x using the false flag
-lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.3/README.md
+++ b/examples/7.3/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.3"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the composer 2.x using the false flag
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.3/README.md
+++ b/examples/7.3/README.md
@@ -46,7 +46,8 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 2."
+lando exec defaults -- composer --version --no-ansi
+!! | grep "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +64,8 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.3"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | grep "Composer version 2."
+lando exec custom -- composer --version --no-ansi
+!! | grep "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -111,7 +113,8 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the composer 2.x using the false flag
-lando exec cliworker -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi
+!! | grep "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.3/README.md
+++ b/examples/7.3/README.md
@@ -46,8 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi
-!! | grep "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -64,8 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.3"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi
-!! | grep "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -113,8 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the composer 2.x using the false flag
-lando exec cliworker -- composer --version --no-ansi
-!! | grep "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.4/README.md
+++ b/examples/7.4/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.4"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.4/README.md
+++ b/examples/7.4/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.4"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.4/README.md
+++ b/examples/7.4/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.4"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/7.4/README.md
+++ b/examples/7.4/README.md
@@ -46,7 +46,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -63,7 +63,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 7.4"
 
 # Should install composer 2.x if 2-latest is set
-lando exec custom -- composer --version --no-ansi | grep "Composer version 2."
+lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/8.0/README.md
+++ b/examples/8.0/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 8.0"
 
 # Should install composer 2.1.12 if version number is set
-lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.12"
+lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.1.12"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/8.0/README.md
+++ b/examples/8.0/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 8.0"
 
 # Should install composer 2.1.12 if version number is set
-lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.1.12"
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.12"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/8.0/README.md
+++ b/examples/8.0/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 8.0"
 
 # Should install composer 2.1.12 if version number is set
-lando exec custom -- composer --version --no-ansi | grep "Composer version 2.1.12"
+lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.1.12"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/8.0/README.md
+++ b/examples/8.0/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | grep "PHP 8.0"
 
 # Should install composer 2.1.12 if version number is set
-lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.1.12"
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.12"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | grep v14.

--- a/examples/8.1/README.md
+++ b/examples/8.1/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.1"
 
 # Should install composer 2.1.12 if version number is set
-lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.12"
+lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.1.12"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.1/README.md
+++ b/examples/8.1/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.1"
 
 # Should install composer 2.1.12 if version number is set
-lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.1.12"
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.12"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.1/README.md
+++ b/examples/8.1/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.1"
 
 # Should install composer 2.1.12 if version number is set
-lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.1.12"
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.12"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.1/README.md
+++ b/examples/8.1/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.1"
 
 # Should install composer 2.1.12 if version number is set
-lando exec custom -- composer --version --no-ansi | grep "Composer version 2.1.12"
+lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.1.12"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.2/README.md
+++ b/examples/8.2/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.2"
 
 # Should install composer 2.2.18 if version number is set
-lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2.18"
+lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2.18"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.2/README.md
+++ b/examples/8.2/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.2"
 
 # Should install composer 2.2.18 if version number is set
-lando exec custom -- composer --version --no-ansi | grep "Composer version 2.2.18"
+lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2.18"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.2/README.md
+++ b/examples/8.2/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.2"
 
 # Should install composer 2.2.18 if version number is set
-lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2.18"
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2.18"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.2/README.md
+++ b/examples/8.2/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.2"
 
 # Should install composer 2.2.18 if version number is set
-lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2.18"
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2.18"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.3/README.md
+++ b/examples/8.3/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.3"
 
 # Should install composer 2.5.6 if version number is set
-lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.5.6"
+lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.5.6"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.3/README.md
+++ b/examples/8.3/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.3"
 
 # Should install composer 2.5.6 if version number is set
-lando exec custom -- composer --version --no-ansi | grep "Composer version 2.5.6"
+lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.5.6"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.3/README.md
+++ b/examples/8.3/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.3"
 
 # Should install composer 2.5.6 if version number is set
-lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.5.6"
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.5.6"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.3/README.md
+++ b/examples/8.3/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.3"
 
 # Should install composer 2.5.6 if version number is set
-lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.5.6"
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.5.6"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -75,7 +75,7 @@ lando exec custom -- php -m | grep "xdebug"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -111,7 +111,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node14 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.4/README.md
+++ b/examples/8.4/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.4"
 
 # Should install composer 2.5.6 if version number is set
-lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.5.6"
+lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.5.6"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -72,7 +72,7 @@ lando exec custom_nginx -- curl https://localhost | grep "WEBDIR"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -108,7 +108,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should have node 18 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.4/README.md
+++ b/examples/8.4/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.4"
 
 # Should install composer 2.5.6 if version number is set
-lando exec custom -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.5.6"
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.5.6"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -72,7 +72,7 @@ lando exec custom_nginx -- curl https://localhost | grep "WEBDIR"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -108,7 +108,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node 18 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.4/README.md
+++ b/examples/8.4/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | grep "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.4"
 
 # Should install composer 2.5.6 if version number is set
-lando exec custom -- composer --version --no-ansi | grep "Composer version 2.5.6"
+lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.5.6"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -72,7 +72,7 @@ lando exec custom_nginx -- curl https://localhost | grep "WEBDIR"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -108,7 +108,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | grep "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should have node 18 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/8.4/README.md
+++ b/examples/8.4/README.md
@@ -43,7 +43,7 @@ lando exec defaults -- curl http://localhost | grep "memory_limit" | grep "1G"
 lando exec defaults -- env | grep "COMPOSER_MEMORY_LIMIT=-1"
 
 # Should install composer 2.x by default
-lando exec defaults -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec defaults -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have unlimited memory for php for CLI opts
 lando php -i | grep memory_limit | grep -e "-1"
@@ -60,7 +60,7 @@ lando exec custom_nginx -- curl https://localhost | grep SERVER | grep PATH_TRAN
 lando exec custom -- php -v | tee >(cat 1>&2) | grep "PHP 8.4"
 
 # Should install composer 2.5.6 if version number is set
-lando exec custom -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.5.6"
+lando exec custom -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.5.6"
 
 # Should serve via nginx if specified
 lando exec custom_nginx -- curl http://localhost | grep "WEBDIR"
@@ -72,7 +72,7 @@ lando exec custom_nginx -- curl https://localhost | grep "WEBDIR"
 lando exec cli -- curl http://localhost || echo $? | grep 7
 
 # Should install the composer 2.x using the false flag
-lando exec cli -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cli -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should use custom php ini if specified
 lando exec custom -- php -i | grep memory_limit | grep 514
@@ -108,7 +108,7 @@ lando exec defaults -- curl http://localhost/path_info.php/a/b.php | grep SCRIPT
 lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 
 # Should install the latest composer 2.x by default.
-lando exec cliworker -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec cliworker -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should have node 18 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v18.

--- a/examples/composer/.lando.yml
+++ b/examples/composer/.lando.yml
@@ -22,6 +22,15 @@ services:
   composer2ver:
     type: php
     composer_version: '2.1.10'
+  composer22:
+    type: php
+    composer_version: 2.2
+  composer22latest:
+    type: php
+    composer_version: 2.2-latest
+  composer22ver:
+    type: php
+    composer_version: '2.2.10'
   dependencies:
     type: php
     composer_version: 2

--- a/examples/composer/.lando.yml
+++ b/examples/composer/.lando.yml
@@ -1,5 +1,9 @@
 name: lando-phpcomposer
 services:
+  php72:
+    type: php:7.2
+  php83:
+    type: php:8.3
   composer1:
     type: php
     composer_version: 1

--- a/examples/composer/README.md
+++ b/examples/composer/README.md
@@ -46,6 +46,15 @@ lando exec composer2latest -- composer --version --no-ansi | tee >(cat 1>&2) | g
 # Should install composer 2.1.10 if composer_version set to specific version
 lando exec composer2ver -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.10"
 
+# Should install composer 2.2.x if composer_version set to 2.2
+lando exec composer22 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
+
+# Should install composer 2.2.x if composer_version set to 2.2-latest
+lando exec composer22latest -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
+
+# Should install composer 2.2.10 if composer_version set to 2.2.10
+lando exec composer22ver -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2.10"
+
 # Should install compose global dependencies if specified by user and have them available in PATH
 lando exec dependencies -- phpunit --version
 lando exec dependencies -- which phpunit | grep "/var/www/.composer/vendor/bin/phpunit"

--- a/examples/composer/README.md
+++ b/examples/composer/README.md
@@ -22,6 +22,12 @@ lando start
 Run the following commands to validate things are rolling as they should.
 
 ```bash
+# PHP 7.2 Should install composer 2.2.x by default
+lando exec php72 -- composer --version --no-ansi | grep "Composer version 2.2."
+
+# PHP 8.3 Should install composer 2.8.x by default
+lando exec php83 -- composer --version --no-ansi | grep "Composer version 2.8."
+
 # Should install composer 1.x if composer_version set to 1
 lando exec composer1 -- composer --version --no-ansi | grep "Composer version 1."
 

--- a/examples/composer/README.md
+++ b/examples/composer/README.md
@@ -23,28 +23,28 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # PHP 7.2 Should install composer 2.2.x by default
-lando exec php72 -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
+lando exec php72 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 
 # PHP 8.3 Should install composer 2.8.x by default
-lando exec php83 -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.8."
+lando exec php83 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.8."
 
 # Should install composer 1.x if composer_version set to 1
-lando exec composer1 -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
+lando exec composer1 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should install composer 1.x if composer_version set to 1-latest
-lando exec composer1latest -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
+lando exec composer1latest -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should install composer 1.10.21 if composer_version set to specific version
-lando exec composer1ver -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1.10.21"
+lando exec composer1ver -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1.10.21"
 
 # Should install composer 2.x if composer_version set to 2
-lando exec composer2 -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec composer2 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should install composer 2.x if composer_version set to 2-latest
-lando exec composer2latest -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
+lando exec composer2latest -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should install composer 2.1.10 if composer_version set to specific version
-lando exec composer2ver -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.1.10"
+lando exec composer2ver -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.10"
 
 # Should install compose global dependencies if specified by user and have them available in PATH
 lando exec dependencies -- phpunit --version

--- a/examples/composer/README.md
+++ b/examples/composer/README.md
@@ -23,28 +23,28 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # PHP 7.2 Should install composer 2.2.x by default
-lando exec php72 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
+lando exec php72 -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
 
 # PHP 8.3 Should install composer 2.8.x by default
-lando exec php83 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.8."
+lando exec php83 -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.8."
 
 # Should install composer 1.x if composer_version set to 1
-lando exec composer1 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
+lando exec composer1 -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
 
 # Should install composer 1.x if composer_version set to 1-latest
-lando exec composer1latest -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
+lando exec composer1latest -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
 
 # Should install composer 1.10.21 if composer_version set to specific version
-lando exec composer1ver -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1.10.21"
+lando exec composer1ver -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1.10.21"
 
 # Should install composer 2.x if composer_version set to 2
-lando exec composer2 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec composer2 -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should install composer 2.x if composer_version set to 2-latest
-lando exec composer2latest -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
+lando exec composer2latest -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
 
 # Should install composer 2.1.10 if composer_version set to specific version
-lando exec composer2ver -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.10"
+lando exec composer2ver -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.1.10"
 
 # Should install compose global dependencies if specified by user and have them available in PATH
 lando exec dependencies -- phpunit --version

--- a/examples/composer/README.md
+++ b/examples/composer/README.md
@@ -23,28 +23,28 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # PHP 7.2 Should install composer 2.2.x by default
-lando exec php72 -- composer --version --no-ansi | grep "Composer version 2.2."
+lando exec php72 -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.2."
 
 # PHP 8.3 Should install composer 2.8.x by default
-lando exec php83 -- composer --version --no-ansi | grep "Composer version 2.8."
+lando exec php83 -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.8."
 
 # Should install composer 1.x if composer_version set to 1
-lando exec composer1 -- composer --version --no-ansi | grep "Composer version 1."
+lando exec composer1 -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
 
 # Should install composer 1.x if composer_version set to 1-latest
-lando exec composer1latest -- composer --version --no-ansi | grep "Composer version 1."
+lando exec composer1latest -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1."
 
 # Should install composer 1.10.21 if composer_version set to specific version
-lando exec composer1ver -- composer --version --no-ansi | grep "Composer version 1.10.21"
+lando exec composer1ver -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 1.10.21"
 
 # Should install composer 2.x if composer_version set to 2
-lando exec composer2 -- composer --version --no-ansi | grep "Composer version 2."
+lando exec composer2 -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should install composer 2.x if composer_version set to 2-latest
-lando exec composer2latest -- composer --version --no-ansi | grep "Composer version 2."
+lando exec composer2latest -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2."
 
 # Should install composer 2.1.10 if composer_version set to specific version
-lando exec composer2ver -- composer --version --no-ansi | grep "Composer version 2.1.10"
+lando exec composer2ver -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.1.10"
 
 # Should install compose global dependencies if specified by user and have them available in PATH
 lando exec dependencies -- phpunit --version

--- a/examples/composer/README.md
+++ b/examples/composer/README.md
@@ -23,28 +23,28 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # PHP 7.2 Should install composer 2.2.x by default
-lando exec php72 -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.2."
+lando exec php72 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.2."
 
 # PHP 8.3 Should install composer 2.8.x by default
-lando exec php83 -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.8."
+lando exec php83 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.8."
 
 # Should install composer 1.x if composer_version set to 1
-lando exec composer1 -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
+lando exec composer1 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should install composer 1.x if composer_version set to 1-latest
-lando exec composer1latest -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1."
+lando exec composer1latest -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1."
 
 # Should install composer 1.10.21 if composer_version set to specific version
-lando exec composer1ver -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 1.10.21"
+lando exec composer1ver -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 1.10.21"
 
 # Should install composer 2.x if composer_version set to 2
-lando exec composer2 -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec composer2 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should install composer 2.x if composer_version set to 2-latest
-lando exec composer2latest -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2."
+lando exec composer2latest -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2."
 
 # Should install composer 2.1.10 if composer_version set to specific version
-lando exec composer2ver -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.1.10"
+lando exec composer2ver -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.10"
 
 # Should install compose global dependencies if specified by user and have them available in PATH
 lando exec dependencies -- phpunit --version

--- a/examples/custom/README.md
+++ b/examples/custom/README.md
@@ -32,7 +32,7 @@ lando exec withnode -- php -v | grep "PHP 7.4"
 lando exec custom81 -- php -v | grep "PHP 8.1"
 
 # Should install composer 2.1.14 if version number is set
-lando exec custom81 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.14"
+lando exec custom81 -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.1.14"
 
 # Should use nginx version 1.17.x as the webserver version
 lando exec custom81_nginx --  nginx -v 2>&1 | grep 1.17

--- a/examples/custom/README.md
+++ b/examples/custom/README.md
@@ -32,7 +32,7 @@ lando exec withnode -- php -v | grep "PHP 7.4"
 lando exec custom81 -- php -v | grep "PHP 8.1"
 
 # Should install composer 2.1.14 if version number is set
-lando exec custom81 -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.1.14"
+lando exec custom81 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.14"
 
 # Should use nginx version 1.17.x as the webserver version
 lando exec custom81_nginx --  nginx -v 2>&1 | grep 1.17

--- a/examples/custom/README.md
+++ b/examples/custom/README.md
@@ -32,7 +32,7 @@ lando exec withnode -- php -v | grep "PHP 7.4"
 lando exec custom81 -- php -v | grep "PHP 8.1"
 
 # Should install composer 2.1.14 if version number is set
-lando exec custom81 -- composer --version --no-ansi | grep "Composer version 2.1.14"
+lando exec custom81 -- composer --version --no-ansi | tee /dev/tty | grep -q "Composer version 2.1.14"
 
 # Should use nginx version 1.17.x as the webserver version
 lando exec custom81_nginx --  nginx -v 2>&1 | grep 1.17

--- a/examples/custom/README.md
+++ b/examples/custom/README.md
@@ -32,7 +32,7 @@ lando exec withnode -- php -v | grep "PHP 7.4"
 lando exec custom81 -- php -v | grep "PHP 8.1"
 
 # Should install composer 2.1.14 if version number is set
-lando exec custom81 -- composer --version --no-ansi | tee >(tail -n 1 >&2) | grep -q "Composer version 2.1.14"
+lando exec custom81 -- composer --version --no-ansi | tee >(cat 1>&2) | grep -q "Composer version 2.1.14"
 
 # Should use nginx version 1.17.x as the webserver version
 lando exec custom81_nginx --  nginx -v 2>&1 | grep 1.17

--- a/examples/php-extensions/.lando.yml
+++ b/examples/php-extensions/.lando.yml
@@ -1,7 +1,7 @@
 name: lando-php-extensions
 services:
-  84scripted:
-    type: php:8.4
+  83scripted:
+    type: php:8.3
     build_as_root:
       - install-php-extensions swoole
   buildsteps:

--- a/examples/php-extensions/README.md
+++ b/examples/php-extensions/README.md
@@ -24,7 +24,7 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # Should have installed the needed php extensions
-lando exec 84scripted -- php -m | grep swoole
+lando exec 83scripted -- php -m | grep swoole
 lando exec buildsteps -- php -m | grep stats
 lando exec buildsteps -- php -m | grep xsl
 lando exec dockerfile -- php -m | grep oci8

--- a/images/5.6-apache/Dockerfile
+++ b/images/5.6-apache/Dockerfile
@@ -72,11 +72,7 @@ RUN \
     intl \
     gettext \
     pcntl \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
-  && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/5.6-apache/Dockerfile
+++ b/images/5.6-apache/Dockerfile
@@ -73,7 +73,7 @@ RUN \
     gettext \
     pcntl \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \

--- a/images/5.6-fpm/Dockerfile
+++ b/images/5.6-fpm/Dockerfile
@@ -72,12 +72,7 @@ RUN \
     intl \
     gettext \
     pcntl \
-  # Install composer
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
-  && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/5.6-fpm/Dockerfile
+++ b/images/5.6-fpm/Dockerfile
@@ -74,7 +74,7 @@ RUN \
     pcntl \
   # Install composer
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \

--- a/images/7.0-apache/Dockerfile
+++ b/images/7.0-apache/Dockerfile
@@ -72,11 +72,7 @@ RUN \
     intl \
     gettext \
     pcntl \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
-  && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.0-apache/Dockerfile
+++ b/images/7.0-apache/Dockerfile
@@ -73,7 +73,7 @@ RUN \
     gettext \
     pcntl \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \

--- a/images/7.0-fpm/Dockerfile
+++ b/images/7.0-fpm/Dockerfile
@@ -72,11 +72,7 @@ RUN \
     intl \
     gettext \
     pcntl \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
-  && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.0-fpm/Dockerfile
+++ b/images/7.0-fpm/Dockerfile
@@ -73,7 +73,7 @@ RUN \
     gettext \
     pcntl \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \

--- a/images/7.1-apache/Dockerfile
+++ b/images/7.1-apache/Dockerfile
@@ -75,11 +75,7 @@ RUN \
     intl \
     gettext \
     pcntl \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
-  && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.1-apache/Dockerfile
+++ b/images/7.1-apache/Dockerfile
@@ -76,7 +76,7 @@ RUN \
     gettext \
     pcntl \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \

--- a/images/7.1-fpm/Dockerfile
+++ b/images/7.1-fpm/Dockerfile
@@ -75,11 +75,7 @@ RUN \
     intl \
     gettext \
     pcntl \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
-  && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.1-fpm/Dockerfile
+++ b/images/7.1-fpm/Dockerfile
@@ -76,7 +76,7 @@ RUN \
     gettext \
     pcntl \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \

--- a/images/7.2-apache/Dockerfile
+++ b/images/7.2-apache/Dockerfile
@@ -73,11 +73,7 @@ RUN \
     intl \
     gettext \
     pcntl \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
-  && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.2-apache/Dockerfile
+++ b/images/7.2-apache/Dockerfile
@@ -74,7 +74,7 @@ RUN \
     gettext \
     pcntl \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \

--- a/images/7.2-fpm/Dockerfile
+++ b/images/7.2-fpm/Dockerfile
@@ -73,11 +73,7 @@ RUN \
     intl \
     gettext \
     pcntl \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
-  && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
-  && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \

--- a/images/7.2-fpm/Dockerfile
+++ b/images/7.2-fpm/Dockerfile
@@ -74,7 +74,7 @@ RUN \
     gettext \
     pcntl \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.1 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.27 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && su -c "composer global require -n hirak/prestissimo" -s /bin/sh www-data \

--- a/images/7.3-apache/Dockerfile
+++ b/images/7.3-apache/Dockerfile
@@ -70,7 +70,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     gettext \
     pcntl \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.2.12 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.2.24 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/7.3-apache/Dockerfile
+++ b/images/7.3-apache/Dockerfile
@@ -69,9 +69,6 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     intl \
     gettext \
     pcntl \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.2.24 \
-  && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \
   && apt-get -y autoclean \

--- a/images/7.3-fpm/Dockerfile
+++ b/images/7.3-fpm/Dockerfile
@@ -70,7 +70,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     gettext \
     pcntl \
   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.2.12 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.2.24 \
   && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/7.3-fpm/Dockerfile
+++ b/images/7.3-fpm/Dockerfile
@@ -69,9 +69,6 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     intl \
     gettext \
     pcntl \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.2.24 \
-  && php -r "unlink('composer-setup.php');" \
   && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \
   && apt-get -y autoclean \

--- a/images/7.4-apache/Dockerfile
+++ b/images/7.4-apache/Dockerfile
@@ -59,7 +59,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.12
+RUN install-php-extensions @composer-2.2.24
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/7.4-apache/Dockerfile
+++ b/images/7.4-apache/Dockerfile
@@ -59,8 +59,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.24
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/7.4-fpm/Dockerfile
+++ b/images/7.4-fpm/Dockerfile
@@ -59,7 +59,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.12
+RUN install-php-extensions @composer-2.2.24
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/7.4-fpm/Dockerfile
+++ b/images/7.4-fpm/Dockerfile
@@ -59,8 +59,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.24
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/8.0-apache/Dockerfile
+++ b/images/8.0-apache/Dockerfile
@@ -59,8 +59,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.24
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/8.0-apache/Dockerfile
+++ b/images/8.0-apache/Dockerfile
@@ -59,7 +59,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
+RUN install-php-extensions @composer-2.2.24
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.0-fpm/Dockerfile
+++ b/images/8.0-fpm/Dockerfile
@@ -59,8 +59,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.24
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/8.0-fpm/Dockerfile
+++ b/images/8.0-fpm/Dockerfile
@@ -59,7 +59,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
+RUN install-php-extensions @composer-2.2.24
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.1-apache/Dockerfile
+++ b/images/8.1-apache/Dockerfile
@@ -57,7 +57,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.24
+RUN install-php-extensions @composer-2
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.1-apache/Dockerfile
+++ b/images/8.1-apache/Dockerfile
@@ -57,8 +57,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/8.1-apache/Dockerfile
+++ b/images/8.1-apache/Dockerfile
@@ -57,7 +57,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
+RUN install-php-extensions @composer-2.2.24
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.1-fpm/Dockerfile
+++ b/images/8.1-fpm/Dockerfile
@@ -57,7 +57,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.24
+RUN install-php-extensions @composer-2
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.1-fpm/Dockerfile
+++ b/images/8.1-fpm/Dockerfile
@@ -57,8 +57,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/8.1-fpm/Dockerfile
+++ b/images/8.1-fpm/Dockerfile
@@ -57,7 +57,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
+RUN install-php-extensions @composer-2.2.24
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.2-apache/Dockerfile
+++ b/images/8.2-apache/Dockerfile
@@ -57,7 +57,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.24
+RUN install-php-extensions @composer-2
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.2-apache/Dockerfile
+++ b/images/8.2-apache/Dockerfile
@@ -57,8 +57,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/8.2-apache/Dockerfile
+++ b/images/8.2-apache/Dockerfile
@@ -57,7 +57,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
+RUN install-php-extensions @composer-2.2.24
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.2-fpm/Dockerfile
+++ b/images/8.2-fpm/Dockerfile
@@ -57,7 +57,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.24
+RUN install-php-extensions @composer-2
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.2-fpm/Dockerfile
+++ b/images/8.2-fpm/Dockerfile
@@ -57,8 +57,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/8.2-fpm/Dockerfile
+++ b/images/8.2-fpm/Dockerfile
@@ -57,7 +57,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
+RUN install-php-extensions @composer-2.2.24
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.3-apache/Dockerfile
+++ b/images/8.3-apache/Dockerfile
@@ -68,7 +68,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
+RUN install-php-extensions @composer-2.2.24
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.3-apache/Dockerfile
+++ b/images/8.3-apache/Dockerfile
@@ -68,7 +68,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.24
+RUN install-php-extensions @composer-2
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.3-apache/Dockerfile
+++ b/images/8.3-apache/Dockerfile
@@ -68,8 +68,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/8.3-fpm/Dockerfile
+++ b/images/8.3-fpm/Dockerfile
@@ -69,8 +69,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/8.3-fpm/Dockerfile
+++ b/images/8.3-fpm/Dockerfile
@@ -69,7 +69,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
+RUN install-php-extensions @composer-2.2.24
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.3-fpm/Dockerfile
+++ b/images/8.3-fpm/Dockerfile
@@ -69,7 +69,7 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2.2.24
+RUN install-php-extensions @composer-2
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.4-apache/Dockerfile
+++ b/images/8.4-apache/Dockerfile
@@ -70,8 +70,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/images/8.4-fpm/Dockerfile
+++ b/images/8.4-fpm/Dockerfile
@@ -71,8 +71,6 @@ RUN \
 RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
-RUN install-php-extensions @composer-2
-
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \

--- a/scripts/install-composer.sh
+++ b/scripts/install-composer.sh
@@ -16,6 +16,10 @@ elif [ "$VERSION" = '2-latest' ]; then
   php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --2
 elif [ "$VERSION" = '2' ]; then
   php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --2
+elif [ "$VERSION" = '2.2' ]; then
+  php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --2.2
+elif [ "$VERSION" = '2.2-latest' ]; then
+  php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --2.2
 elif [ "$VERSION" = 'preview' ]; then
   php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --preview
 elif [ "$VERSION" = 'snapshot' ]; then

--- a/utils/add-build-step.js
+++ b/utils/add-build-step.js
@@ -3,9 +3,23 @@
 // Modules
 const _ = require('lodash');
 
-/*
- * Helper to get global deps
- * @TODO: this looks pretty testable? should services have libs?
+/**
+ * Helper function to add build steps to a service's configuration
+ *
+ * @param {string|string[]} steps - The build step(s) to add
+ * @param {Object} app - The Lando app object
+ * @param {string} name - The name of the service
+ * @param {string} [step='build_internal'] - The build step type to modify
+ * @param {boolean} [front=false] - Whether to add steps to front of array
+ * @return {void} - Modifies app config object directly
+ *
+ * @example
+ * // Add a build step to the end
+ * addBuildStep('npm install', app, 'web');
+ *
+ * @example
+ * // Add multiple build steps to the front
+ * addBuildStep(['composer install', 'npm install'], app, 'web', 'build_internal', true);
  */
 module.exports = (steps, app, name, step = 'build_internal', front = false) => {
   const current = _.get(app, `config.services.${name}.${step}`, []);

--- a/utils/get-install-commands.js
+++ b/utils/get-install-commands.js
@@ -3,9 +3,25 @@
 // Modules
 const _ = require('lodash');
 
-/*
- * Helper to get global deps
- * @TODO: this looks pretty testable? should services have libs?
+/**
+ * Helper function to generate installation commands for dependencies
+ *
+ * @param {Object} deps - Dependencies object with package names as keys and versions as values
+ * @param {Function} pkger - Function that generates package installation command
+ * @param {string[]} [prefix=[]] - Command prefix to prepend to each installation command
+ * @return {string[]} Array of formatted installation commands
+ *
+ * @example
+ * // Generate npm install commands
+ * const deps = { 'lodash': '^4.0.0', 'express': '4.17.1' };
+ * const npmInstall = (pkg, version) => ['npm', 'install', `${pkg}@${version}`];
+ * getInstallCommands(deps, npmInstall);
+ * // Returns: ['npm install lodash@^4.0.0', 'npm install express@4.17.1']
+ *
+ * @example
+ * // Generate commands with prefix
+ * getInstallCommands(deps, npmInstall, ['sudo', '-E']);
+ * // Returns: ['sudo -E npm install lodash@^4.0.0', 'sudo -E npm install express@4.17.1']
  */
 module.exports = (deps, pkger, prefix = []) => _(deps)
   .map((version, pkg) => _.flatten([prefix, pkger(pkg, version)]))


### PR DESCRIPTION
Some newer things, e.g. Symfony 7 Console, aren't compatible with old composer. Old PHP is not compatible with new composer.

This PR updates the default Composer version from 2.2.22 to 2.8.2, with additional logic to set the defaults to the appropriate LTS versions for older PHP versions.

I also updated patch versions of Composer in the images.