### PR TITLE
Extensions and Clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
 * Updated 8.4RC image to 8.4 stable.
-* Added `xdebug-beta` and `imagick` extension to PHP 8.4 images.
+* Added `xdebug` and `imagick` extension to PHP 8.4 images.
+* Added `xhprof` extension to PHP 7.4+ images.
+* Added `imagick` extension to PHP 8.3 images.
 
 ## v1.6.3 - [December 7, 2024](https://github.com/lando/php/releases/tag/v1.6.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `xdebug` and `imagick` extension to PHP 8.4 images.
 * Added `xhprof` extension to PHP 7.4-8.4 images.
 * Added `imagick` extension to PHP 8.3 images.
+* Updated `sqlite3` to 3.45.1 in PHP 8.3-8.4 images.
 
 ## v1.6.3 - [December 7, 2024](https://github.com/lando/php/releases/tag/v1.6.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Updated 8.4RC image to 8.4 stable.
+* Added `xdebug-beta` and `imagick` extension to PHP 8.4 images.
+
 ## v1.6.3 - [December 7, 2024](https://github.com/lando/php/releases/tag/v1.6.3)
 
 * Optimized for `midcore`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
 * Updated 8.4RC image to 8.4 stable.
+* Added MariaDB client tools to PHP 7.4-8.4 images [#120](https://github.com/lando/php/issues/120).
 * Added `xdebug` and `imagick` extension to PHP 8.4 images.
-* Added `xhprof` extension to PHP 7.4+ images.
+* Added `xhprof` extension to PHP 7.4-8.4 images.
 * Added `imagick` extension to PHP 8.3 images.
 
 ## v1.6.3 - [December 7, 2024](https://github.com/lando/php/releases/tag/v1.6.3)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -8,7 +8,7 @@ description: Learn what extensions are installed in the Lando PHP plugin
 |           | 5.3 | 5.4 | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 | 7.3 | 7.4 | 8.0 | 8.1 | 8.2 | 8.3 | 8.4 |
 | --        | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | apc       |  X  |  X  |     |     |     |     |     |     |     |     |     |     |     |     |
-| apcu      |     |     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |     |     |     |     |  X  |
+| apcu      |     |     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | bcmath    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | bz2       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | calendar  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
@@ -25,7 +25,7 @@ description: Learn what extensions are installed in the Lando PHP plugin
 | gettext   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | hash      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | iconv     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| imagick   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  *  |     |
+| imagick   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | imap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | intl      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | json      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
@@ -33,10 +33,10 @@ description: Learn what extensions are installed in the Lando PHP plugin
 | libxml    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | mbstring  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | mcrypt    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| memcached |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |     |     |     |     |  X  |
+| memcached |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | mysqli    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | mysqlnd   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| OAuth     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |     |     |     |     |  X  |
+| OAuth     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | OPcache   |     |     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | openssl   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | pcntl     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
@@ -58,18 +58,15 @@ description: Learn what extensions are installed in the Lando PHP plugin
 | sqlite3   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | standard  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | tokenizer |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| xdebug    |     |     |     |     |     |     |     |     |     |     |     |     |     |     |
+| xdebug    |  *  |  *  |  *  |  *  |  *  |  *  |  *  |  *  |  *  |  *  |  *  |  *  |  *  |  *  |
+| xhprof    |     |     |     |     |     |     |     |     |  X  |  X  |  X  |  X  |  X  |  X  |
 | xml       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | xmlreader |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | xmlwriter |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | zip       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 | zlib      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 
-Note that `xdebug` is off by default but you can enable it by setting your `php` services config to `xdebug: true`. Read more about this in "Configuration" above.
-
-::: warning
-Note that imagick is temporarily unavailable on PHP 8.3/8.4, due to a pending issue waiting to get released on the imagick project: https://github.com/Imagick/imagick/pull/641
-:::
+__*__ Note that `xdebug` is off by default but you can enable it by setting your `php` services config to `xdebug: true`. Read more about this in "Configuration" above.
 
 ## Adding or removing extensions
 

--- a/images/7.4-apache/Dockerfile
+++ b/images/7.4-apache/Dockerfile
@@ -2,29 +2,14 @@
 
 FROM php:7.4-apache-bullseye
 
-# Install dependencies we need
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
-    bzip2 \
     default-mysql-client \
     exiftool \
     git-core \
     gnupg2 \
-    imagemagick \
-    libbz2-dev \
-    libc-client-dev \
-    libicu-dev \
-    libjpeg62-turbo-dev \
-    libkrb5-dev \
-    libldap2-dev \
-    libmagickwand-dev \
-    libmemcached-dev \
-    libpng-dev \
-    libpq-dev \
-    libssl-dev \
-    libwebp-dev \
-    libxml2-dev \
-    libzip-dev \
     libonig-dev \
     openssl \
     postgresql-client-13 \
@@ -34,46 +19,41 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     unzip \
     wget \
     xfonts-75dpi \
-    xfonts-base \
-    zlib1g-dev \
-  && pecl install apcu \
-  && pecl install imagick \
-  && pecl install memcached \
-  && pecl install oauth-2.0.4 \
-  && pecl install redis-5.1.1 \
-  && pecl install xdebug-3.1.6 \
-  && pecl install xhprof \
-  && docker-php-ext-configure ldap --with-libdir=lib/$(uname -m)-linux-gnu/ \
-  && docker-php-ext-enable apcu \
-  && docker-php-ext-enable imagick \
-  && docker-php-ext-enable memcached \
-  && docker-php-ext-enable oauth \
-  && docker-php-ext-enable redis \
-  && docker-php-ext-install bcmath \
-  && docker-php-ext-install bz2 \
-  && docker-php-ext-install calendar \
-  && docker-php-ext-install exif \
-  && docker-php-ext-install gettext \
-  && docker-php-ext-install intl \
-  && docker-php-ext-install ldap \
-  && docker-php-ext-install mbstring \
-  && docker-php-ext-install mysqli \
-  && docker-php-ext-install opcache \
-  && docker-php-ext-install pcntl \
-  && docker-php-ext-install pdo \
-  && docker-php-ext-install pdo_mysql \
-  && docker-php-ext-install pdo_pgsql \
-  && docker-php-ext-install soap \
-  && docker-php-ext-install zip \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.2.12 \
-  && php -r "unlink('composer-setup.php');" \
-  && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
+    xfonts-base
+
+RUN \
+  install-php-extensions @fix_letsencrypt \
+  && install-php-extensions apcu \
+  && install-php-extensions bcmath \
+  && install-php-extensions bz2 \
+  && install-php-extensions calendar \
+  && install-php-extensions exif \
+  && install-php-extensions gd \
+  && install-php-extensions gettext \
+  && install-php-extensions imagick \
+  && install-php-extensions imap \
+  && install-php-extensions intl \
+  && install-php-extensions ldap \
+  && install-php-extensions mbstring \
+  && install-php-extensions memcached \
+  && install-php-extensions mysqli \
+  && install-php-extensions oauth \
+  && install-php-extensions opcache \
+  && install-php-extensions pcntl \
+  && install-php-extensions pdo \
+  && install-php-extensions pdo_mysql \
+  && install-php-extensions pdo_pgsql \
+  && install-php-extensions redis \
+  && install-php-extensions soap \
+  && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
+  && install-php-extensions zip
+
+RUN install-php-extensions @composer-2.2.12
+
+RUN \
+  chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \
-  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/* \
-  && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
-  && docker-php-ext-install imap \
-  && docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp \
-  && docker-php-ext-install gd
+  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*

--- a/images/7.4-apache/Dockerfile
+++ b/images/7.4-apache/Dockerfile
@@ -42,6 +42,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && pecl install oauth-2.0.4 \
   && pecl install redis-5.1.1 \
   && pecl install xdebug-3.1.6 \
+  && pecl install xhprof \
   && docker-php-ext-configure ldap --with-libdir=lib/$(uname -m)-linux-gnu/ \
   && docker-php-ext-enable apcu \
   && docker-php-ext-enable imagick \

--- a/images/7.4-apache/Dockerfile
+++ b/images/7.4-apache/Dockerfile
@@ -4,6 +4,12 @@ FROM php:7.4-apache-bullseye
 
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
+RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.5/debian bullseye main" > /etc/apt/sources.list.d/mariadb.list
+
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
     default-mysql-client \
@@ -11,6 +17,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     git-core \
     gnupg2 \
     libonig-dev \
+    mariadb-client \
     openssl \
     postgresql-client-13 \
     pv \

--- a/images/7.4-fpm/Dockerfile
+++ b/images/7.4-fpm/Dockerfile
@@ -42,6 +42,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && pecl install oauth-2.0.4 \
   && pecl install redis-5.1.1 \
   && pecl install xdebug-3.1.6 \
+  && pecl install xhprof \
   && docker-php-ext-configure ldap --with-libdir=lib/$(uname -m)-linux-gnu/ \
   && docker-php-ext-enable apcu \
   && docker-php-ext-enable imagick \

--- a/images/7.4-fpm/Dockerfile
+++ b/images/7.4-fpm/Dockerfile
@@ -4,6 +4,12 @@ FROM php:7.4-fpm-bullseye
 
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
+RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.5/debian bullseye main" > /etc/apt/sources.list.d/mariadb.list
+
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
   default-mysql-client \
@@ -11,6 +17,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   git-core \
   gnupg2 \
   libonig-dev \
+  mariadb-client \
   openssl \
   postgresql-client-13 \
   pv \

--- a/images/7.4-fpm/Dockerfile
+++ b/images/7.4-fpm/Dockerfile
@@ -2,78 +2,58 @@
 
 FROM php:7.4-fpm-bullseye
 
-# Install dependencies we need
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
-    bzip2 \
-    default-mysql-client \
-    exiftool \
-    git-core \
-    gnupg2 \
-    imagemagick \
-    libbz2-dev \
-    libc-client-dev \
-    libicu-dev \
-    libjpeg62-turbo-dev \
-    libkrb5-dev \
-    libldap2-dev \
-    libmagickwand-dev \
-    libmemcached-dev \
-    libpng-dev \
-    libpq-dev \
-    libssl-dev \
-    libwebp-dev \
-    libxml2-dev \
-    libzip-dev \
-    libonig-dev \
-    openssl \
-    postgresql-client-13 \
-    pv \
-    rsync \
-    ssh \
-    unzip \
-    wget \
-    xfonts-75dpi \
-    xfonts-base \
-    zlib1g-dev \
-  && pecl install apcu \
-  && pecl install imagick \
-  && pecl install memcached \
-  && pecl install oauth-2.0.4 \
-  && pecl install redis-5.1.1 \
-  && pecl install xdebug-3.1.6 \
-  && pecl install xhprof \
-  && docker-php-ext-configure ldap --with-libdir=lib/$(uname -m)-linux-gnu/ \
-  && docker-php-ext-enable apcu \
-  && docker-php-ext-enable imagick \
-  && docker-php-ext-enable memcached \
-  && docker-php-ext-enable oauth \
-  && docker-php-ext-enable redis \
-  && docker-php-ext-install bcmath \
-  && docker-php-ext-install bz2 \
-  && docker-php-ext-install calendar \
-  && docker-php-ext-install exif \
-  && docker-php-ext-install gettext \
-  && docker-php-ext-install intl \
-  && docker-php-ext-install ldap \
-  && docker-php-ext-install mbstring \
-  && docker-php-ext-install mysqli \
-  && docker-php-ext-install opcache \
-  && docker-php-ext-install pcntl \
-  && docker-php-ext-install pdo \
-  && docker-php-ext-install pdo_mysql \
-  && docker-php-ext-install pdo_pgsql \
-  && docker-php-ext-install soap \
-  && docker-php-ext-install zip \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.2.12 \
-  && php -r "unlink('composer-setup.php');" \
-  && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
+  default-mysql-client \
+  exiftool \
+  git-core \
+  gnupg2 \
+  libonig-dev \
+  openssl \
+  postgresql-client-13 \
+  pv \
+  rsync \
+  ssh \
+  unzip \
+  wget \
+  xfonts-75dpi \
+  xfonts-base
+
+RUN \
+  install-php-extensions @fix_letsencrypt \
+  && install-php-extensions apcu \
+  && install-php-extensions bcmath \
+  && install-php-extensions bz2 \
+  && install-php-extensions calendar \
+  && install-php-extensions exif \
+  && install-php-extensions gd \
+  && install-php-extensions gettext \
+  && install-php-extensions imagick \
+  && install-php-extensions imap \
+  && install-php-extensions intl \
+  && install-php-extensions ldap \
+  && install-php-extensions mbstring \
+  && install-php-extensions memcached \
+  && install-php-extensions mysqli \
+  && install-php-extensions oauth \
+  && install-php-extensions opcache \
+  && install-php-extensions pcntl \
+  && install-php-extensions pdo \
+  && install-php-extensions pdo_mysql \
+  && install-php-extensions pdo_pgsql \
+  && install-php-extensions redis \
+  && install-php-extensions soap \
+  && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
+  && install-php-extensions zip
+
+RUN install-php-extensions @composer-2.2.12
+
+RUN \
+  chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \
-  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/* \
-  && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
-  && docker-php-ext-install imap \
-  && docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp \
-  && docker-php-ext-install gd
+  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*

--- a/images/8.0-apache/Dockerfile
+++ b/images/8.0-apache/Dockerfile
@@ -4,6 +4,12 @@ FROM php:8.0-apache-bullseye
 
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
+RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.5/debian bullseye main" > /etc/apt/sources.list.d/mariadb.list
+
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
     default-mysql-client \
@@ -11,6 +17,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     git-core \
     gnupg2 \
     libonig-dev \
+    mariadb-client \
     openssl \
     postgresql-client-13 \
     pv \

--- a/images/8.0-apache/Dockerfile
+++ b/images/8.0-apache/Dockerfile
@@ -43,6 +43,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && pecl install oauth \
   && pecl install redis-5.3.2 \
   && pecl install xdebug \
+  && pecl install xhprof \
   && docker-php-ext-configure ldap --with-libdir=lib/$(uname -m)-linux-gnu/ \
   && docker-php-ext-enable apcu \
   && docker-php-ext-enable imagick \

--- a/images/8.0-apache/Dockerfile
+++ b/images/8.0-apache/Dockerfile
@@ -2,30 +2,14 @@
 
 FROM php:8.0-apache-bullseye
 
-# Install dependencies we need
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
-    bzip2 \
     default-mysql-client \
     exiftool \
     git-core \
     gnupg2 \
-    imagemagick \
-    libbz2-dev \
-    libc-client-dev \
-    libfreetype6-dev \
-    libicu-dev \
-    libjpeg62-turbo-dev \
-    libkrb5-dev \
-    libldap2-dev \
-    libmagickwand-dev \
-    libmemcached-dev \
-    libpng-dev \
-    libpq-dev \
-    libssl-dev \
-    libwebp-dev \
-    libxml2-dev \
-    libzip-dev \
     libonig-dev \
     openssl \
     postgresql-client-13 \
@@ -35,46 +19,41 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     unzip \
     wget \
     xfonts-75dpi \
-    xfonts-base \
-    zlib1g-dev \
-  && pecl install apcu \
-  && pecl install imagick \
-  && pecl install memcached \
-  && pecl install oauth \
-  && pecl install redis-5.3.2 \
-  && pecl install xdebug \
-  && pecl install xhprof \
-  && docker-php-ext-configure ldap --with-libdir=lib/$(uname -m)-linux-gnu/ \
-  && docker-php-ext-enable apcu \
-  && docker-php-ext-enable imagick \
-  && docker-php-ext-enable memcached \
-  && docker-php-ext-enable oauth \
-  && docker-php-ext-enable redis \
-  && docker-php-ext-install bcmath \
-  && docker-php-ext-install bz2 \
-  && docker-php-ext-install calendar \
-  && docker-php-ext-install exif \
-  && docker-php-ext-install gettext \
-  && docker-php-ext-install intl \
-  && docker-php-ext-install ldap \
-  && docker-php-ext-install mbstring \
-  && docker-php-ext-install mysqli \
-  && docker-php-ext-install opcache \
-  && docker-php-ext-install pcntl \
-  && docker-php-ext-install pdo \
-  && docker-php-ext-install pdo_mysql \
-  && docker-php-ext-install pdo_pgsql \
-  && docker-php-ext-install soap \
-  && docker-php-ext-install zip \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.2.12 \
-  && php -r "unlink('composer-setup.php');" \
-  && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
+    xfonts-base
+
+RUN \
+  install-php-extensions @fix_letsencrypt \
+  && install-php-extensions apcu \
+  && install-php-extensions bcmath \
+  && install-php-extensions bz2 \
+  && install-php-extensions calendar \
+  && install-php-extensions exif \
+  && install-php-extensions gd \
+  && install-php-extensions gettext \
+  && install-php-extensions imagick \
+  && install-php-extensions imap \
+  && install-php-extensions intl \
+  && install-php-extensions ldap \
+  && install-php-extensions mbstring \
+  && install-php-extensions memcached \
+  && install-php-extensions mysqli \
+  && install-php-extensions oauth \
+  && install-php-extensions opcache \
+  && install-php-extensions pcntl \
+  && install-php-extensions pdo \
+  && install-php-extensions pdo_mysql \
+  && install-php-extensions pdo_pgsql \
+  && install-php-extensions redis \
+  && install-php-extensions soap \
+  && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
+  && install-php-extensions zip
+
+RUN install-php-extensions @composer-2
+
+RUN \
+  chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \
-  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/* \
-  && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
-  && docker-php-ext-install imap \
-  && docker-php-ext-configure gd --enable-gd --with-jpeg --with-webp --with-freetype \
-  && docker-php-ext-install gd
+  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*

--- a/images/8.0-fpm/Dockerfile
+++ b/images/8.0-fpm/Dockerfile
@@ -43,6 +43,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && pecl install oauth \
   && pecl install redis-5.3.2 \
   && pecl install xdebug \
+  && pecl install xhprof \
   && docker-php-ext-configure ldap --with-libdir=lib/$(uname -m)-linux-gnu/ \
   && docker-php-ext-enable apcu \
   && docker-php-ext-enable imagick \

--- a/images/8.0-fpm/Dockerfile
+++ b/images/8.0-fpm/Dockerfile
@@ -2,30 +2,14 @@
 
 FROM php:8.0-fpm-bullseye
 
-# Install dependencies we need
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
-    bzip2 \
     default-mysql-client \
     exiftool \
     git-core \
     gnupg2 \
-    imagemagick \
-    libbz2-dev \
-    libc-client-dev \
-    libfreetype6-dev \
-    libicu-dev \
-    libjpeg62-turbo-dev \
-    libkrb5-dev \
-    libldap2-dev \
-    libmagickwand-dev \
-    libmemcached-dev \
-    libpng-dev \
-    libpq-dev \
-    libssl-dev \
-    libwebp-dev \
-    libxml2-dev \
-    libzip-dev \
     libonig-dev \
     openssl \
     postgresql-client-13 \
@@ -35,46 +19,41 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     unzip \
     wget \
     xfonts-75dpi \
-    xfonts-base \
-    zlib1g-dev \
-  && pecl install apcu \
-  && pecl install imagick \
-  && pecl install memcached \
-  && pecl install oauth \
-  && pecl install redis-5.3.2 \
-  && pecl install xdebug \
-  && pecl install xhprof \
-  && docker-php-ext-configure ldap --with-libdir=lib/$(uname -m)-linux-gnu/ \
-  && docker-php-ext-enable apcu \
-  && docker-php-ext-enable imagick \
-  && docker-php-ext-enable memcached \
-  && docker-php-ext-enable oauth \
-  && docker-php-ext-enable redis \
-  && docker-php-ext-install bcmath \
-  && docker-php-ext-install bz2 \
-  && docker-php-ext-install calendar \
-  && docker-php-ext-install exif \
-  && docker-php-ext-install gettext \
-  && docker-php-ext-install intl \
-  && docker-php-ext-install ldap \
-  && docker-php-ext-install mbstring \
-  && docker-php-ext-install mysqli \
-  && docker-php-ext-install opcache \
-  && docker-php-ext-install pcntl \
-  && docker-php-ext-install pdo \
-  && docker-php-ext-install pdo_mysql \
-  && docker-php-ext-install pdo_pgsql \
-  && docker-php-ext-install soap \
-  && docker-php-ext-install zip \
-  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=2.2.12 \
-  && php -r "unlink('composer-setup.php');" \
-  && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
+    xfonts-base
+
+RUN \
+  install-php-extensions @fix_letsencrypt \
+  && install-php-extensions apcu \
+  && install-php-extensions bcmath \
+  && install-php-extensions bz2 \
+  && install-php-extensions calendar \
+  && install-php-extensions exif \
+  && install-php-extensions gd \
+  && install-php-extensions gettext \
+  && install-php-extensions imagick \
+  && install-php-extensions imap \
+  && install-php-extensions intl \
+  && install-php-extensions ldap \
+  && install-php-extensions mbstring \
+  && install-php-extensions memcached \
+  && install-php-extensions mysqli \
+  && install-php-extensions oauth \
+  && install-php-extensions opcache \
+  && install-php-extensions pcntl \
+  && install-php-extensions pdo \
+  && install-php-extensions pdo_mysql \
+  && install-php-extensions pdo_pgsql \
+  && install-php-extensions redis \
+  && install-php-extensions soap \
+  && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
+  && install-php-extensions zip
+
+RUN install-php-extensions @composer-2
+
+RUN \
+  chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \
-  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/* \
-  && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
-  && docker-php-ext-install imap \
-  && docker-php-ext-configure gd --enable-gd --with-jpeg --with-webp --with-freetype \
-  && docker-php-ext-install gd
+  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*

--- a/images/8.0-fpm/Dockerfile
+++ b/images/8.0-fpm/Dockerfile
@@ -4,6 +4,12 @@ FROM php:8.0-fpm-bullseye
 
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
+RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.5/debian bullseye main" > /etc/apt/sources.list.d/mariadb.list
+
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
     default-mysql-client \
@@ -11,6 +17,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     git-core \
     gnupg2 \
     libonig-dev \
+    mariadb-client \
     openssl \
     postgresql-client-13 \
     pv \

--- a/images/8.1-apache/Dockerfile
+++ b/images/8.1-apache/Dockerfile
@@ -44,6 +44,7 @@ RUN \
   && install-php-extensions redis \
   && install-php-extensions soap \
   && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.1-apache/Dockerfile
+++ b/images/8.1-apache/Dockerfile
@@ -5,12 +5,19 @@ FROM php:8.1-apache-bookworm
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.11/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
+
+RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
   default-mysql-client \
   exiftool \
   git-core \
   gnupg2 \
+  mariadb-client \
   openssl \
   postgresql-client-15 \
   pv \

--- a/images/8.1-fpm/Dockerfile
+++ b/images/8.1-fpm/Dockerfile
@@ -44,6 +44,7 @@ RUN \
   && install-php-extensions redis \
   && install-php-extensions soap \
   && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.1-fpm/Dockerfile
+++ b/images/8.1-fpm/Dockerfile
@@ -5,12 +5,19 @@ FROM php:8.1-fpm-bookworm
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.11/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
+
+RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
   default-mysql-client \
   exiftool \
   git-core \
   gnupg2 \
+  mariadb-client \
   openssl \
   postgresql-client-15 \
   pv \

--- a/images/8.2-apache/Dockerfile
+++ b/images/8.2-apache/Dockerfile
@@ -44,6 +44,7 @@ RUN \
   && install-php-extensions redis \
   && install-php-extensions soap \
   && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.2-apache/Dockerfile
+++ b/images/8.2-apache/Dockerfile
@@ -5,12 +5,19 @@ FROM php:8.2-apache-bookworm
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.11/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
+
+RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
   default-mysql-client \
   exiftool \
   git-core \
   gnupg2 \
+  mariadb-client \
   openssl \
   postgresql-client-15 \
   pv \

--- a/images/8.2-fpm/Dockerfile
+++ b/images/8.2-fpm/Dockerfile
@@ -44,6 +44,7 @@ RUN \
   && install-php-extensions redis \
   && install-php-extensions soap \
   && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.2-fpm/Dockerfile
+++ b/images/8.2-fpm/Dockerfile
@@ -5,12 +5,19 @@ FROM php:8.2-fpm-bookworm
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.11/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
+
+RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
   default-mysql-client \
   exiftool \
   git-core \
   gnupg2 \
+  mariadb-client \
   openssl \
   postgresql-client-15 \
   pv \

--- a/images/8.3-apache/Dockerfile
+++ b/images/8.3-apache/Dockerfile
@@ -44,6 +44,7 @@ RUN \
   && install-php-extensions redis \
   && install-php-extensions soap \
   && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.3-apache/Dockerfile
+++ b/images/8.3-apache/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM php:8.3-apache-bookworm
 
+ARG TARGETARCH
+
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
@@ -54,6 +56,13 @@ RUN \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2
+
+# Drupal 11 requires sqlite3 3.45+
+ARG SQLITE_VERSION=3.45.1
+RUN \
+  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && dpkg -i /tmp/sqlite3.deb /tmp/libsqlite3-0.deb
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.3-apache/Dockerfile
+++ b/images/8.3-apache/Dockerfile
@@ -5,6 +5,12 @@ FROM php:8.3-apache-bookworm
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.11/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
+
+RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
   default-mysql-client \

--- a/images/8.3-fpm/Dockerfile
+++ b/images/8.3-fpm/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM php:8.3-fpm-bookworm
 
+ARG TARGETARCH
+
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
@@ -55,6 +57,13 @@ RUN \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2
+
+# Drupal 11 requires sqlite3 3.45+
+ARG SQLITE_VERSION=3.45.1
+RUN \
+  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && dpkg -i /tmp/sqlite3.deb /tmp/libsqlite3-0.deb
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.3-fpm/Dockerfile
+++ b/images/8.3-fpm/Dockerfile
@@ -44,6 +44,7 @@ RUN \
   && install-php-extensions redis \
   && install-php-extensions soap \
   && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.3-fpm/Dockerfile
+++ b/images/8.3-fpm/Dockerfile
@@ -5,12 +5,19 @@ FROM php:8.3-fpm-bookworm
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.11/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
+
+RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
   default-mysql-client \
   exiftool \
   git-core \
   gnupg2 \
+  mariadb-client \
   openssl \
   postgresql-client-15 \
   pv \

--- a/images/8.4-apache/Dockerfile
+++ b/images/8.4-apache/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM php:8.4-apache-bookworm
 
+ARG TARGETARCH
+
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
@@ -56,6 +58,13 @@ RUN \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2
+
+# Drupal 11 requires sqlite3 3.45+
+ARG SQLITE_VERSION=3.45.1
+RUN \
+  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && dpkg -i /tmp/sqlite3.deb /tmp/libsqlite3-0.deb
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.4-apache/Dockerfile
+++ b/images/8.4-apache/Dockerfile
@@ -44,6 +44,7 @@ RUN \
   && install-php-extensions redis \
   && install-php-extensions soap \
   && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.4-apache/Dockerfile
+++ b/images/8.4-apache/Dockerfile
@@ -43,9 +43,7 @@ RUN \
   && install-php-extensions pdo_pgsql \
   && install-php-extensions redis \
   && install-php-extensions soap \
-  # TODO: switch to xdebug once there is a stable release for PHP 8.4
-  && install-php-extensions xdebug-beta \
-  # install-php-extensions xdebug \
+  && install-php-extensions xdebug \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.4-apache/Dockerfile
+++ b/images/8.4-apache/Dockerfile
@@ -28,6 +28,7 @@ RUN \
   && install-php-extensions exif \
   && install-php-extensions gd \
   && install-php-extensions gettext \
+  && install-php-extensions imagick \
   && install-php-extensions imap \
   && install-php-extensions intl \
   && install-php-extensions ldap \
@@ -42,7 +43,9 @@ RUN \
   && install-php-extensions pdo_pgsql \
   && install-php-extensions redis \
   && install-php-extensions soap \
-  # && install-php-extensions xdebug \
+  # TODO: switch to xdebug once there is a stable release for PHP 8.4
+  && install-php-extensions xdebug-beta \
+  # install-php-extensions xdebug \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.4-apache/Dockerfile
+++ b/images/8.4-apache/Dockerfile
@@ -5,12 +5,20 @@ FROM php:8.4-apache-bookworm
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/11.4/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
+
+RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
     default-mysql-client \
     exiftool \
     git-core \
     gnupg2 \
+    mariadb-client \
+    mariadb-client-compat \
     openssl \
     postgresql-client-15 \
     pv \

--- a/images/8.4-fpm/Dockerfile
+++ b/images/8.4-fpm/Dockerfile
@@ -44,7 +44,9 @@ RUN \
   && install-php-extensions pdo_pgsql \
   && install-php-extensions redis \
   && install-php-extensions soap \
-  && install-php-extensions xdebug \
+  # TODO: switch to xdebug once there is a stable release for PHP 8.4
+  && install-php-extensions xdebug-beta \
+  # install-php-extensions xdebug \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.4-fpm/Dockerfile
+++ b/images/8.4-fpm/Dockerfile
@@ -29,6 +29,7 @@ RUN \
   && install-php-extensions exif \
   && install-php-extensions gd \
   && install-php-extensions gettext \
+  && install-php-extensions imagick \
   && install-php-extensions imap \
   && install-php-extensions intl \
   && install-php-extensions ldap \
@@ -43,7 +44,7 @@ RUN \
   && install-php-extensions pdo_pgsql \
   && install-php-extensions redis \
   && install-php-extensions soap \
-  # && install-php-extensions xdebug \
+  && install-php-extensions xdebug \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.4-fpm/Dockerfile
+++ b/images/8.4-fpm/Dockerfile
@@ -45,6 +45,7 @@ RUN \
   && install-php-extensions redis \
   && install-php-extensions soap \
   && install-php-extensions xdebug \
+  && install-php-extensions xhprof \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2

--- a/images/8.4-fpm/Dockerfile
+++ b/images/8.4-fpm/Dockerfile
@@ -2,13 +2,15 @@
 
 FROM php:8.4-fpm-bookworm
 
+ARG TARGETARCH
+
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
   # MariaDB client compatibility (https://github.com/lando/php/issues/120)
   mkdir -p /etc/apt/keyrings \
   && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
-  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.11/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/11.4/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
 
 RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
@@ -57,6 +59,13 @@ RUN \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2
+
+# Drupal 11 requires sqlite3 3.45+
+ARG SQLITE_VERSION=3.45.1
+RUN \
+  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && dpkg -i /tmp/sqlite3.deb /tmp/libsqlite3-0.deb
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.4-fpm/Dockerfile
+++ b/images/8.4-fpm/Dockerfile
@@ -5,6 +5,12 @@ FROM php:8.4-fpm-bookworm
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN \
+  # MariaDB client compatibility (https://github.com/lando/php/issues/120)
+  mkdir -p /etc/apt/keyrings \
+  && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
+  && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.11/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
+
+RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
     bzip2 \
@@ -12,6 +18,8 @@ RUN \
     exiftool \
     git-core \
     gnupg2 \
+    mariadb-client \
+    mariadb-client-compat \
     openssl \
     postgresql-client-15 \
     pv \

--- a/images/8.4-fpm/Dockerfile
+++ b/images/8.4-fpm/Dockerfile
@@ -44,9 +44,7 @@ RUN \
   && install-php-extensions pdo_pgsql \
   && install-php-extensions redis \
   && install-php-extensions soap \
-  # TODO: switch to xdebug once there is a stable release for PHP 8.4
-  && install-php-extensions xdebug-beta \
-  # install-php-extensions xdebug \
+  && install-php-extensions xdebug \
   && install-php-extensions zip
 
 RUN install-php-extensions @composer-2


### PR DESCRIPTION
* Added MariaDB client tools to PHP 7.4-8.4 images. Resolves #120.
* Added `xdebug` and `imagick` extension to PHP 8.4 images.
* Added `xhprof` extension to PHP 7.4-8.4 images. Resolves #148.
* Added `imagick` extension to PHP 8.3 images. Resolves #114.
* Updated `sqlite3` to 3.45.1 in PHP 8.3-8.4 images. Resolves lando/drupal#119.
* Updated PHP 7.4-8.4 images to use the `install-php-extensions` script. Resolves #116.