### PR TITLE
Fix libsqlite3-dev version mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed mismatched `libsqlite3-dev` and `libsqlite3-0` versions in PHP 8.3 and 8.4 images.
+
 ## v1.6.4 - [December 14, 2024](https://github.com/lando/php/releases/tag/v1.6.4)
 
 * Fixed issue causing `xdebug` extension to not be disabled by default in PHP 8.3 and 8.4 images.

--- a/examples/php-extensions/.lando.yml
+++ b/examples/php-extensions/.lando.yml
@@ -1,5 +1,9 @@
 name: lando-php-extensions
 services:
+  84scripted:
+    type: php:8.4
+    build_as_root:
+      - install-php-extensions swoole
   buildsteps:
     type: php
     build_as_root:

--- a/examples/php-extensions/README.md
+++ b/examples/php-extensions/README.md
@@ -24,6 +24,7 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # Should have installed the needed php extensions
+lando exec 84scripted -- php -m | grep swoole
 lando exec buildsteps -- php -m | grep stats
 lando exec buildsteps -- php -m | grep xsl
 lando exec dockerfile -- php -m | grep oci8

--- a/images/8.3-apache/Dockerfile
+++ b/images/8.3-apache/Dockerfile
@@ -12,6 +12,13 @@ RUN \
   && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
   && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.11/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
 
+# Drupal 11 requires sqlite3 3.45+
+ARG SQLITE_VERSION=3.45.1
+RUN \
+  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-dev.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-dev_${SQLITE_VERSION}-1_${TARGETARCH}.deb"
+
 RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
@@ -25,7 +32,10 @@ RUN \
   rsync \
   ssh \
   unzip \
-  wget
+  wget \
+  /tmp/sqlite3.deb \
+  /tmp/libsqlite3-0.deb \
+  /tmp/libsqlite3-dev.deb
 
 RUN \
   install-php-extensions @fix_letsencrypt \
@@ -59,13 +69,6 @@ RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
 RUN install-php-extensions @composer-2
-
-# Drupal 11 requires sqlite3 3.45+
-ARG SQLITE_VERSION=3.45.1
-RUN \
-  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
-  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
-  && dpkg -i /tmp/sqlite3.deb /tmp/libsqlite3-0.deb
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.3-fpm/Dockerfile
+++ b/images/8.3-fpm/Dockerfile
@@ -12,6 +12,13 @@ RUN \
   && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
   && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.11/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
 
+# Drupal 11 requires sqlite3 3.45+
+ARG SQLITE_VERSION=3.45.1
+RUN \
+  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-dev.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-dev_${SQLITE_VERSION}-1_${TARGETARCH}.deb"
+
 RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
@@ -26,7 +33,10 @@ RUN \
   rsync \
   ssh \
   unzip \
-  wget
+  wget \
+  /tmp/sqlite3.deb \
+  /tmp/libsqlite3-0.deb \
+  /tmp/libsqlite3-dev.deb
 
 RUN \
   install-php-extensions @fix_letsencrypt \
@@ -60,13 +70,6 @@ RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
 RUN install-php-extensions @composer-2
-
-# Drupal 11 requires sqlite3 3.45+
-ARG SQLITE_VERSION=3.45.1
-RUN \
-  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
-  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
-  && dpkg -i /tmp/sqlite3.deb /tmp/libsqlite3-0.deb
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.4-apache/Dockerfile
+++ b/images/8.4-apache/Dockerfile
@@ -12,6 +12,13 @@ RUN \
   && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
   && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/11.4/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
 
+# Drupal 11 requires sqlite3 3.45+
+ARG SQLITE_VERSION=3.45.1
+RUN \
+  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-dev.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-dev_${SQLITE_VERSION}-1_${TARGETARCH}.deb"
+
 RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
@@ -27,7 +34,10 @@ RUN \
     rsync \
     ssh \
     unzip \
-    wget
+    wget \
+    /tmp/sqlite3.deb \
+    /tmp/libsqlite3-0.deb \
+    /tmp/libsqlite3-dev.deb
 
 RUN \
   install-php-extensions @fix_letsencrypt \
@@ -61,13 +71,6 @@ RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
 RUN install-php-extensions @composer-2
-
-# Drupal 11 requires sqlite3 3.45+
-ARG SQLITE_VERSION=3.45.1
-RUN \
-  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
-  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
-  && dpkg -i /tmp/sqlite3.deb /tmp/libsqlite3-0.deb
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/images/8.4-fpm/Dockerfile
+++ b/images/8.4-fpm/Dockerfile
@@ -12,6 +12,13 @@ RUN \
   && curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp' \
   && echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/11.4/debian bookworm main" > /etc/apt/sources.list.d/mariadb.list
 
+# Drupal 11 requires sqlite3 3.45+
+ARG SQLITE_VERSION=3.45.1
+RUN \
+  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
+  && curl -Lo /tmp/libsqlite3-dev.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-dev_${SQLITE_VERSION}-1_${TARGETARCH}.deb"
+
 RUN \
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && apt -y update && apt-get install -y \
@@ -28,7 +35,10 @@ RUN \
     rsync \
     ssh \
     unzip \
-    wget
+    wget \
+    /tmp/sqlite3.deb \
+    /tmp/libsqlite3-0.deb \
+    /tmp/libsqlite3-dev.deb
 
 RUN \
   install-php-extensions @fix_letsencrypt \
@@ -62,13 +72,6 @@ RUN install-php-extensions xdebug \
   && rm -f /usr/local/etc/php/conf.d/*xdebug.ini
 
 RUN install-php-extensions @composer-2
-
-# Drupal 11 requires sqlite3 3.45+
-ARG SQLITE_VERSION=3.45.1
-RUN \
-  curl -Lo /tmp/sqlite3.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
-  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb" \
-  && dpkg -i /tmp/sqlite3.deb /tmp/libsqlite3-0.deb
 
 RUN \
   chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \


### PR DESCRIPTION
When `libsqlite3-dev` is needed, such as when installing the `swoole` PHP module, the `libsqlite3-dev` package requires the matching version of `libsqlite3-0`, which we've updated beyond what's available in the Debian repo for Drupal 11 compatibility in the PHP 8.3 and 8.4 images, so apt can't resolve the dependency.

This PR adds the matching package to the affected images to avoid mismatch issues. It also adds a test for installing `swoole` via the `install-php-extensions` 

Resolves #151