### PR TITLE
Drupal's implementation needs imagemagick binaries

### DIFF
--- a/images/7.4-apache/Dockerfile
+++ b/images/7.4-apache/Dockerfile
@@ -16,6 +16,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     exiftool \
     git-core \
     gnupg2 \
+    imagemagick \
     libonig-dev \
     mariadb-client \
     openssl \

--- a/images/7.4-fpm/Dockerfile
+++ b/images/7.4-fpm/Dockerfile
@@ -16,6 +16,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   exiftool \
   git-core \
   gnupg2 \
+  imagemagick \
   libonig-dev \
   mariadb-client \
   openssl \

--- a/images/8.0-apache/Dockerfile
+++ b/images/8.0-apache/Dockerfile
@@ -16,6 +16,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     exiftool \
     git-core \
     gnupg2 \
+    imagemagick \
     libonig-dev \
     mariadb-client \
     openssl \

--- a/images/8.0-fpm/Dockerfile
+++ b/images/8.0-fpm/Dockerfile
@@ -16,6 +16,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     exiftool \
     git-core \
     gnupg2 \
+    imagemagick \
     libonig-dev \
     mariadb-client \
     openssl \

--- a/images/8.1-apache/Dockerfile
+++ b/images/8.1-apache/Dockerfile
@@ -17,6 +17,7 @@ RUN \
   exiftool \
   git-core \
   gnupg2 \
+  imagemagick \
   mariadb-client \
   openssl \
   postgresql-client-15 \

--- a/images/8.1-fpm/Dockerfile
+++ b/images/8.1-fpm/Dockerfile
@@ -17,6 +17,7 @@ RUN \
   exiftool \
   git-core \
   gnupg2 \
+  imagemagick \
   mariadb-client \
   openssl \
   postgresql-client-15 \

--- a/images/8.2-apache/Dockerfile
+++ b/images/8.2-apache/Dockerfile
@@ -17,6 +17,7 @@ RUN \
   exiftool \
   git-core \
   gnupg2 \
+  imagemagick \
   mariadb-client \
   openssl \
   postgresql-client-15 \

--- a/images/8.2-fpm/Dockerfile
+++ b/images/8.2-fpm/Dockerfile
@@ -17,6 +17,7 @@ RUN \
   exiftool \
   git-core \
   gnupg2 \
+  imagemagick \
   mariadb-client \
   openssl \
   postgresql-client-15 \

--- a/images/8.3-apache/Dockerfile
+++ b/images/8.3-apache/Dockerfile
@@ -26,6 +26,7 @@ RUN \
   exiftool \
   git-core \
   gnupg2 \
+  imagemagick \
   postgresql-client-15 \
   pv \
   rsync \

--- a/images/8.3-apache/Dockerfile
+++ b/images/8.3-apache/Dockerfile
@@ -26,7 +26,6 @@ RUN \
   exiftool \
   git-core \
   gnupg2 \
-  openssl \
   postgresql-client-15 \
   pv \
   rsync \

--- a/images/8.3-fpm/Dockerfile
+++ b/images/8.3-fpm/Dockerfile
@@ -27,7 +27,6 @@ RUN \
   git-core \
   gnupg2 \
   mariadb-client \
-  openssl \
   postgresql-client-15 \
   pv \
   rsync \

--- a/images/8.3-fpm/Dockerfile
+++ b/images/8.3-fpm/Dockerfile
@@ -26,6 +26,7 @@ RUN \
   exiftool \
   git-core \
   gnupg2 \
+  imagemagick \
   mariadb-client \
   postgresql-client-15 \
   pv \

--- a/images/8.4-apache/Dockerfile
+++ b/images/8.4-apache/Dockerfile
@@ -26,6 +26,7 @@ RUN \
     exiftool \
     git-core \
     gnupg2 \
+    imagemagick \
     mariadb-client \
     mariadb-client-compat \
     postgresql-client-15 \

--- a/images/8.4-apache/Dockerfile
+++ b/images/8.4-apache/Dockerfile
@@ -28,7 +28,6 @@ RUN \
     gnupg2 \
     mariadb-client \
     mariadb-client-compat \
-    openssl \
     postgresql-client-15 \
     pv \
     rsync \

--- a/images/8.4-fpm/Dockerfile
+++ b/images/8.4-fpm/Dockerfile
@@ -29,7 +29,6 @@ RUN \
     gnupg2 \
     mariadb-client \
     mariadb-client-compat \
-    openssl \
     postgresql-client-15 \
     pv \
     rsync \

--- a/images/8.4-fpm/Dockerfile
+++ b/images/8.4-fpm/Dockerfile
@@ -27,6 +27,7 @@ RUN \
     exiftool \
     git-core \
     gnupg2 \
+    imagemagick \
     mariadb-client \
     mariadb-client-compat \
     postgresql-client-15 \


### PR DESCRIPTION
Drupal's `imagick` module doesn't use the php extension. Instead it uses the `convert` binary. This PR adds it to the image.

Fixes #155