### PR TITLE
Configure Dependabot for npm and docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/images/*"
+    directories:
+      - "/images/*"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Updated Dependabot configuration to specify npm and docker ecosystems with daily update schedules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `.github/dependabot.yml` to enable daily Dependabot updates for npm at `/` and Docker in `/images/*`.
> 
> - **CI/Dependencies**:
>   - Add `.github/dependabot.yml` to enable daily updates via Dependabot:
>     - `npm` ecosystem at `"/"`
>     - `docker` ecosystem in `"/images/*"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc7458a7e80f25e1f8fd598ba53f53450212b723. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->