### PR TITLE
fix: update Node.js 14.x to 20.x in test examples

### DIFF
--- a/examples/7.1/.lando.yml
+++ b/examples/7.1/.lando.yml
@@ -10,7 +10,7 @@ services:
     composer_version: 1
     via: cli
     build_as_root:
-      - curl -sL https://deb.nodesource.com/setup_14.x | bash -
+      - curl -sL https://deb.nodesource.com/setup_20.x | bash -
       - apt-get update -y
       - apt-get install -y nodejs
   cliworker:

--- a/examples/7.1/README.md
+++ b/examples/7.1/README.md
@@ -116,8 +116,8 @@ lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 # Should not install composer when composer_version is false
 echo $(lando exec cliworker -- composer --version --no-ansi 2>&1) | grep "executable file not found"
 
-# Should have node14 installed in cli service
-lando node -v | grep v14.
+# Should have node20 installed in cli service
+lando node -v | grep v20.
 ```
 
 ## Destroy tests

--- a/examples/7.2/.lando.yml
+++ b/examples/7.2/.lando.yml
@@ -10,7 +10,7 @@ services:
     composer_version: 1
     via: cli
     build_as_root:
-      - curl -sL https://deb.nodesource.com/setup_14.x | bash -
+      - curl -sL https://deb.nodesource.com/setup_20.x | bash -
       - apt-get update -y
       - apt-get install -y nodejs
   cliworker:

--- a/examples/7.2/README.md
+++ b/examples/7.2/README.md
@@ -116,8 +116,8 @@ lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 # Should not install composer when composer_version is false
 echo $(lando exec cliworker -- composer --version --no-ansi 2>&1) | grep "executable file not found"
 
-# Should have node14 installed in cli service
-lando node -v | grep v14.
+# Should have node20 installed in cli service
+lando node -v | grep v20.
 ```
 
 ## Destroy tests

--- a/examples/7.3/.lando.yml
+++ b/examples/7.3/.lando.yml
@@ -9,7 +9,7 @@ services:
     type: php:7.3
     via: cli
     build_as_root:
-      - curl -sL https://deb.nodesource.com/setup_14.x | bash -
+      - curl -sL https://deb.nodesource.com/setup_20.x | bash -
       - apt-get update -y
       - apt-get install -y nodejs
   cliworker:

--- a/examples/7.3/README.md
+++ b/examples/7.3/README.md
@@ -113,8 +113,8 @@ lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 # Should not install composer when composer_version is false
 echo $(lando exec cliworker -- composer --version --no-ansi 2>&1) | grep "executable file not found"
 
-# Should have node14 installed in cli service
-lando node -v | grep v14.
+# Should have node20 installed in cli service
+lando node -v | grep v20.
 ```
 
 ## Destroy tests

--- a/examples/8.1/.lando.yml
+++ b/examples/8.1/.lando.yml
@@ -9,7 +9,7 @@ services:
     type: php:8.1
     via: cli
     build_as_root:
-      - curl -sL https://deb.nodesource.com/setup_14.x | bash -
+      - curl -sL https://deb.nodesource.com/setup_20.x | bash -
       - apt-get update -y
       - apt-get install -y nodejs
   cliworker:

--- a/examples/8.1/README.md
+++ b/examples/8.1/README.md
@@ -111,7 +111,7 @@ lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 echo $(lando exec cliworker -- composer --version --no-ansi 2>&1) | grep "executable file not found"
 
 # Should have node14 installed in cli service
-lando node -v | tee >(cat 1>&2) | grep v18.
+lando node -v | tee >(cat 1>&2) | grep v20.
 ```
 
 ## Destroy tests

--- a/examples/8.2/.lando.yml
+++ b/examples/8.2/.lando.yml
@@ -9,7 +9,7 @@ services:
     type: php:8.2
     via: cli
     build_as_root:
-      - curl -sL https://deb.nodesource.com/setup_14.x | bash -
+      - curl -sL https://deb.nodesource.com/setup_20.x | bash -
       - apt-get update -y
       - apt-get install -y nodejs
   cliworker:

--- a/examples/8.2/README.md
+++ b/examples/8.2/README.md
@@ -111,7 +111,7 @@ lando info -s cliworker --deep | grep Cmd | grep sleep | grep infinity
 echo $(lando exec cliworker -- composer --version --no-ansi 2>&1) | grep "executable file not found"
 
 # Should have node14 installed in cli service
-lando node -v | tee >(cat 1>&2) | grep v18.
+lando node -v | tee >(cat 1>&2) | grep v20.
 ```
 
 ## Destroy tests


### PR DESCRIPTION
Node 14 is EOL and NodeSource dropped the GPG key for 14.x repos, breaking `build_as_root` in examples 7.1, 7.2, 7.3, 8.1, and 8.2.

Updates all five to Node 20.x (LTS) and fixes README assertions to match.