### PR TITLE
fix: rebuild GD extension with external libgd for AVIF support

### DIFF
--- a/images/7.4-apache/Dockerfile
+++ b/images/7.4-apache/Dockerfile
@@ -36,7 +36,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/7.4-fpm/Dockerfile
+++ b/images/7.4-fpm/Dockerfile
@@ -36,7 +36,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/8.0-apache/Dockerfile
+++ b/images/8.0-apache/Dockerfile
@@ -36,7 +36,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/8.0-fpm/Dockerfile
+++ b/images/8.0-fpm/Dockerfile
@@ -36,7 +36,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/8.1-apache/Dockerfile
+++ b/images/8.1-apache/Dockerfile
@@ -34,7 +34,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libavif-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp --with-avif \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/8.1-fpm/Dockerfile
+++ b/images/8.1-fpm/Dockerfile
@@ -34,7 +34,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libavif-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp --with-avif \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/8.2-apache/Dockerfile
+++ b/images/8.2-apache/Dockerfile
@@ -34,7 +34,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libavif-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp --with-avif \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/8.2-fpm/Dockerfile
+++ b/images/8.2-fpm/Dockerfile
@@ -34,7 +34,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libavif-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp --with-avif \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/8.3-apache/Dockerfile
+++ b/images/8.3-apache/Dockerfile
@@ -33,7 +33,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libavif-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp --with-avif \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/8.3-fpm/Dockerfile
+++ b/images/8.3-fpm/Dockerfile
@@ -33,7 +33,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libavif-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp --with-avif \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/8.4-apache/Dockerfile
+++ b/images/8.4-apache/Dockerfile
@@ -33,7 +33,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libavif-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp --with-avif \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/8.4-fpm/Dockerfile
+++ b/images/8.4-fpm/Dockerfile
@@ -34,7 +34,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libavif-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp --with-avif \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick \
   && install-php-extensions imap \

--- a/images/8.5-apache/Dockerfile
+++ b/images/8.5-apache/Dockerfile
@@ -33,7 +33,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libavif-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp --with-avif \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick/imagick@master \
   && install-php-extensions imap \

--- a/images/8.5-fpm/Dockerfile
+++ b/images/8.5-fpm/Dockerfile
@@ -34,7 +34,9 @@ RUN \
   && install-php-extensions bz2 \
   && install-php-extensions calendar \
   && install-php-extensions exif \
-  && install-php-extensions gd \
+  && apt-get update && apt-get install -y libgd-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libavif-dev && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-configure gd --with-external-gd --with-freetype --with-jpeg --with-webp --with-avif \
+  && docker-php-ext-install -j$(nproc) gd \
   && install-php-extensions gettext \
   && install-php-extensions imagick/imagick@master \
   && install-php-extensions imap \


### PR DESCRIPTION
Rebuilds the GD PHP extension with `--with-external-gd` and AVIF support in all PHP Docker images. This updates GD from the bundled 2.1.0 to system libgd 2.3.3+.

Fixes #166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the `gd` extension is built in all published images and adds new OS-level dependencies, which could affect build stability and runtime image size/compatibility.
> 
> **Overview**
> Replaces `install-php-extensions gd` with a manual GD build across PHP `7.4`–`8.5` Apache/FPM images by installing system GD build deps and compiling via `docker-php-ext-configure`/`docker-php-ext-install` with `--with-external-gd`.
> 
> For PHP `8.1+`, the GD build is additionally configured with `--with-avif` and installs `libavif-dev`, enabling AVIF support while keeping existing extension installs unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9594768b049605485a03c3748ebeab7e2d0bc60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->