### PR TITLE
test: add GD AVIF support verification for PHP 8.3+

### DIFF
--- a/examples/8.3/README.md
+++ b/examples/8.3/README.md
@@ -112,6 +112,9 @@ echo $(lando exec cliworker -- composer --version --no-ansi 2>&1) | grep "execut
 
 # Should have node22 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v22.
+
+# Should have GD with AVIF support
+lando php -r 'phpinfo();' | grep "GD Support" && lando php -r 'if (!function_exists("imageavif")) { echo "AVIF NOT SUPPORTED\n"; exit(1); } echo "AVIF OK\n";'
 ```
 
 ## Destroy tests

--- a/examples/8.4/README.md
+++ b/examples/8.4/README.md
@@ -109,6 +109,9 @@ echo $(lando exec cliworker -- composer --version --no-ansi 2>&1) | grep "execut
 
 # Should have node 22 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v22.
+
+# Should have GD with AVIF support
+lando php -r 'phpinfo();' | grep "GD Support" && lando php -r 'if (!function_exists("imageavif")) { echo "AVIF NOT SUPPORTED\n"; exit(1); } echo "AVIF OK\n";'
 ```
 
 ## Destroy tests

--- a/examples/8.5/README.md
+++ b/examples/8.5/README.md
@@ -109,6 +109,9 @@ echo $(lando exec cliworker -- composer --version --no-ansi 2>&1) | grep "execut
 
 # Should have node 22 installed in cli service
 lando node -v | tee >(cat 1>&2) | grep v22.
+
+# Should have GD with AVIF support
+lando php -r 'phpinfo();' | grep "GD Support" && lando php -r 'if (!function_exists("imageavif")) { echo "AVIF NOT SUPPORTED\n"; exit(1); } echo "AVIF OK\n";'
 ```
 
 ## Destroy tests


### PR DESCRIPTION
Adds test assertions to verify GD is built with AVIF support on PHP 8.3+ images.

Relates to #166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/test-only changes that add an additional runtime assertion; no production code paths or security-sensitive logic are modified.
> 
> **Overview**
> Adds a new verification step to the PHP `8.3`, `8.4`, and `8.5` example READMEs to assert GD is present *and* built with AVIF support.
> 
> The added commands check for GD via `phpinfo()` output and fail the run if `imageavif()` is unavailable, tightening CI/validation coverage for the shipped PHP images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76df9b67a177831d954fea9a068dcb54ebb38ad6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->