### PR TITLE
Fix/mariadb mysqldump loose option

### DIFF
--- a/scripts/mariadb-compat-install.sh
+++ b/scripts/mariadb-compat-install.sh
@@ -33,6 +33,10 @@ default-character-set=utf8mb4
 [client-mariadb]
 # Prevent SSL errors when connecting to servers without SSL
 disable-ssl-verify-server-cert
+
+[mysqldump]
+# MySQL 8 uses this; MariaDB safely ignores it via loose- prefix
+loose-skip-column-statistics
 MYCNF
 
 echo "MariaDB compatibility wrappers installed"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single config-option tweak in an install script; low blast radius and no security- or data-sensitive logic changes.
> 
> **Overview**
> Updates `scripts/mariadb-compat-install.sh` to write `mysqldump` config as `loose-skip-column-statistics` instead of `skip-column-statistics`, so the option is applied on MySQL 8 while being safely ignored by MariaDB.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7bc4505a9f4baddc85c6f7bfe05f573cb0da8ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->