### PR TITLE
feat: promote npm edge tag to latest on release edit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # When a prerelease is edited to a full release, just promote the npm tag
   promote:
-    if: github.event.action == 'edited' && !github.event.release.prerelease && !github.event.release.draft
+    if: github.event.action == 'edited' && !github.event.release.prerelease && !github.event.release.draft && github.event.changes.prerelease.from == true
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -21,11 +21,12 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Promote edge to latest
         run: |
-          VERSION=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
+          VERSION=$(echo "$TAG_NAME" | sed 's/^v//')
           PACKAGE=$(node -p "require('./package.json').name")
           npm dist-tag add "$PACKAGE@$VERSION" latest
           echo "::notice title=Promoted $VERSION to latest::The latest tag now points to $VERSION (was edge-only)"
         env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
           NODE_AUTH_TOKEN: ${{secrets.NPM_DEPLOY_TOKEN}}
 
   deploy:


### PR DESCRIPTION
## Problem

When a release is published as a prerelease, it gets tagged as `edge` on npm. Later, when the release is edited in GitHub to mark it as a full release, the npm `latest` tag doesn't update because the workflow only triggered on `published`.

## Solution

- Added `edited` to the release workflow trigger types
- New lightweight `promote` job that only runs `npm dist-tag add latest` — no install, no lint, no tests, no re-publish
- Gated so it only fires when: `edited` + not a prerelease + not a draft
- Existing `deploy` job is now explicitly gated to `published` events only (no behavior change)

## Flow

1. Publish as prerelease → full pipeline runs, publishes with `edge` tag (unchanged)
2. Edit release → uncheck prerelease → `promote` job runs, points `latest` to that version (~15s)

The `dist-tag add` command is idempotent, so editing a non-prerelease release description is harmless.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adjusts npm dist-tags based on GitHub release edits; limited blast radius but could mis-tag `latest` if the event gating/conditions are incorrect.
> 
> **Overview**
> Updates the release workflow to also trigger on `release.edited` events.
> 
> Adds a new `promote` job that runs only when a prerelease flag is turned off (and release is not draft), and updates npm by promoting the edited release version to the `latest` dist-tag via `npm dist-tag add`.
> 
> Explicitly gates the existing `deploy` job to `release.published` events to avoid running the full publish/test pipeline on edits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e29e7b92d15415fe75cd0c20fb6fe887a8288e6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->