### PR TITLE
fix: prevent composer install script failure on prestissimo check

### DIFF
--- a/scripts/install-composer.sh
+++ b/scripts/install-composer.sh
@@ -31,10 +31,12 @@ fi
 # Remove the setup script
 php -r "unlink('/tmp/composer-setup.php');"
 
-# Check if anything is installed globally
-if [ -f /var/www/.composer/composer.json ]; then
-  # If this is version 2 then let's make sure hirak/prestissimo is removed
-  if composer --version 2>/dev/null | grep -E "Composer (version )?2." > /dev/null; then
-    composer global remove hirak/prestissimo
+# If upgrading from Composer 1 to 2, remove the prestissimo plugin
+# which is incompatible with Composer 2 (parallel downloads are built-in now).
+# Use COMPOSER_HOME to find the right global composer.json for the current user.
+COMPOSER_HOME="${COMPOSER_HOME:-$(composer global config home --quiet 2>/dev/null || echo '')}"
+if [ -n "$COMPOSER_HOME" ] && [ -f "$COMPOSER_HOME/composer.json" ]; then
+  if composer --version 2>/dev/null | grep -qE "Composer (version )?2\."; then
+    composer global remove hirak/prestissimo 2>/dev/null || true
   fi
 fi


### PR DESCRIPTION
## Problem

`install-composer.sh` checks for `/var/www/.composer/composer.json` but runs `composer global remove hirak/prestissimo` as root, where `COMPOSER_HOME` resolves to `/root/.config/composer`. When that directory has no `composer.json`, the command fails and `set -e` kills the entire build step.

This causes the **joomla-import** leia test to fail on `lando rebuild` in every downstream recipe that uses the PHP builder (e.g. lando/joomla).

## Fix

- Use `COMPOSER_HOME` to resolve the correct global `composer.json` path
- Add `|| true` so even if the remove fails, it doesn't break the build
- The `hirak/prestissimo` package hasn't been relevant since Composer 1 anyway

## Downstream

Fixes CI failures in:
- lando/joomla#68
- lando/joomla (all branches)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script change limited to Composer installation cleanup; main risk is masking a real failure due to `|| true`, but it only affects optional plugin removal.
> 
> **Overview**
> Prevents `scripts/install-composer.sh` from failing during Composer installs by making the prestissimo cleanup conditional on the *actual* global config location.
> 
> The script now resolves `COMPOSER_HOME` (via env or `composer global config home`), checks for `$COMPOSER_HOME/composer.json`, and attempts `composer global remove hirak/prestissimo` only when running Composer 2, swallowing any removal errors so `set -e` doesn’t break the build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0736e47e3f8109d7f29446273ebabfbfbf12610. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->