### PR TITLE
fix: remove legacy prestissimo cleanup causing composer crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed composer install crash caused by legacy prestissimo removal running as wrong user
 * Improved composer install script to default to latest stable
 * Fixed `mysqldump` warning for unknown option on MariaDB 11.4/11.8 [#237](https://github.com/lando/php/issues/237)
 * Updated to [@lando/nginx@1.6.0](https://github.com/lando/nginx/releases/tag/v1.6.0)

--- a/scripts/install-composer.sh
+++ b/scripts/install-composer.sh
@@ -32,11 +32,3 @@ fi
 
 # Remove the setup script
 php -r "unlink('/tmp/composer-setup.php');"
-
-# Check if anything is installed globally
-if [ -f /var/www/.composer/composer.json ]; then
-  # If this is version 2 then let's make sure hirak/prestissimo is removed
-  if composer --version 2>/dev/null | grep -E "Composer (version )?2." > /dev/null; then
-    composer global remove hirak/prestissimo
-  fi
-fi


### PR DESCRIPTION
## Summary

Removes the legacy `hirak/prestissimo` cleanup block from `install-composer.sh` that was causing composer to crash during Laravel (and other recipe) builds.

## Root Cause

Commit `01586fb` moved composer installation from `build_internal` to `build_as_root_internal`, meaning `install-composer.sh` now runs as **root** instead of the service user (www-data).

The prestissimo cleanup block checked for a global `composer.json` at `/var/www/.composer/` (www-data's dir), but `composer global remove` as root targets `/root/.config/composer/composer.json` — which doesn't exist. This path mismatch causes:

```
Changed current directory to /root/.config/composer
In JsonFile.php line 114:
  Could not read ./composer.json
```

This only triggers on **rebuilds** where `/var/www/.composer/composer.json` persists from a previous build via volume mounts.

## Fix

Remove the prestissimo cleanup entirely. `hirak/prestissimo` was a Composer 1 parallel-download plugin that Composer 2 made obsolete in 2020. The cleanup code is no longer needed.

## Testing

- Fresh `lando start` with Laravel recipe
- `lando rebuild` with persistent composer volumes
- Composer 1 and Composer 2 builds (neither affected by removal)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an obsolete post-install cleanup step and only affects Composer install-time behavior; main risk is missing any previously relied-on global plugin removal in edge cases.
> 
> **Overview**
> Fixes a Composer install crash by **removing the legacy `hirak/prestissimo` global cleanup** from `scripts/install-composer.sh`, avoiding failures when the script runs under a different user context.
> 
> Updates `CHANGELOG.md` to note the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92cad259d0c2a5e131705fb03f12d3d1b190ac9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->